### PR TITLE
Dependency factory 의존성 중복 수정

### DIFF
--- a/WalWal/App/Project.swift
+++ b/WalWal/App/Project.swift
@@ -30,7 +30,6 @@ let project = Project(
       resources: ["Resources/**"],
       entitlements: "../WalWal.entitlements",
       dependencies: [
-        .DependencyFactory.Interface,
         .DependencyFactory.Implement
       ]
     )

--- a/WalWal/App/Project.swift
+++ b/WalWal/App/Project.swift
@@ -30,14 +30,8 @@ let project = Project(
       resources: ["Resources/**"],
       entitlements: "../WalWal.entitlements",
       dependencies: [
-        .WalWalNetwork.Interface,
-        .WalWalNetwork.Implement,
-        
         .DependencyFactory.Interface,
-        .DependencyFactory.Implement,
-        
-        .Coordinator.App.Interface,
-        .Coordinator.App.Implement
+        .DependencyFactory.Implement
       ]
     )
   ]

--- a/WalWal/Coordinators/App/AppCoordinator/Project.swift
+++ b/WalWal/Coordinators/App/AppCoordinator/Project.swift
@@ -16,15 +16,8 @@ let project = Project.invertedDualTargetProject(
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
     .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
   ],
   implementDependencies: [
-    .DependencyFactory.Interface,
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .DependencyFactory.Interface
   ]
 )

--- a/WalWal/Coordinators/App/AppCoordinator/Project.swift
+++ b/WalWal/Coordinators/App/AppCoordinator/Project.swift
@@ -21,8 +21,8 @@ let project = Project.invertedDualTargetProject(
     .ThirdParty.RxCocoa
   ],
   implementDependencies: [
-    .Coordinator.Base.Interface,
     .DependencyFactory.Interface,
+    .Coordinator.Base.Interface,
     
     .ThirdParty.RxSwift,
     .ThirdParty.RxCocoa

--- a/WalWal/Coordinators/Base/BaseCoordinator/Project.swift
+++ b/WalWal/Coordinators/Base/BaseCoordinator/Project.swift
@@ -32,7 +32,6 @@ let project = Project(
       infoPlist: .default,
       sources: ["Sources/**"],
       dependencies: [
-        .ThirdParty.RxSwift,
         .ThirdParty.RxCocoa
       ]
     ),

--- a/WalWal/Coordinators/SampleApp/SampleAppCoordinator/Project.swift
+++ b/WalWal/Coordinators/SampleApp/SampleAppCoordinator/Project.swift
@@ -24,9 +24,6 @@ let project = Project.invertedDualTargetProject(
     .DependencyFactory.Interface,
     .Coordinator.Base.Interface,
     
-    .Coordinator.SampleAuth.Interface,
-    .Coordinator.SampleHome.Interface,
-    
     .ThirdParty.RxSwift,
     .ThirdParty.RxCocoa
   ]

--- a/WalWal/Coordinators/SampleApp/SampleAppCoordinator/Project.swift
+++ b/WalWal/Coordinators/SampleApp/SampleAppCoordinator/Project.swift
@@ -15,17 +15,10 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .Coordinator.Base.Interface
   ],
   implementDependencies: [
-    .DependencyFactory.Interface,
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .DependencyFactory.Interface
   ]
 )
 

--- a/WalWal/Coordinators/SampleAuth/SampleAuthCoordinator/Project.swift
+++ b/WalWal/Coordinators/SampleAuth/SampleAuthCoordinator/Project.swift
@@ -15,17 +15,10 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .Coordinator.Base.Interface
   ],
   implementDependencies: [
-    .DependencyFactory.Interface,
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .DependencyFactory.Interface
   ]
 )
 

--- a/WalWal/Coordinators/SampleHome/SampleHomeCoordinator/Project.swift
+++ b/WalWal/Coordinators/SampleHome/SampleHomeCoordinator/Project.swift
@@ -15,17 +15,10 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .Coordinator.Base.Interface
   ],
   implementDependencies: [
-    .DependencyFactory.Interface,
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .DependencyFactory.Interface
   ]
 )
 

--- a/WalWal/DependencyFactory/Implement/DependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/Implement/DependencyFactoryImp.swift
@@ -8,8 +8,6 @@
 import UIKit
 import DependencyFactory
 
-// MARK: - 추가되는 Feature에 따라 import되는 Interface와 Implement를 작성해주세요.
-
 import WalWalNetwork
 import WalWalNetworkImp
 
@@ -45,10 +43,12 @@ public class DependencyFactoryImp: DependencyFactory {
   
   // MARK: - 추가되는 Coordinator에 따라 Dependency를 생성 및 주입하는 함수의 구현부를 작성해주새요
   
-  public func makeSampleAppCoordinator(
-    navigationController: UINavigationController
-  ) -> any SampleAppCoordinator {
-    return SampleAppCoordinatorImp(navigationController: navigationController, parentCoordinator: nil, dependencyFactory: self)
+  public func makeSampleAppCoordinator(navigationController: UINavigationController) -> any SampleAppCoordinator {
+    return SampleAppCoordinatorImp(
+      navigationController: navigationController,
+      parentCoordinator: nil,
+      dependencyFactory: self
+    )
   }
   
   public func makeSampleAuthCoordinator(navigationController: UINavigationController, parentCoordinator: any BaseCoordinator) -> any SampleAuthCoordinator {
@@ -86,11 +86,11 @@ public class DependencyFactoryImp: DependencyFactory {
   // MARK: - 추가되는 Feature에 따라 Domain Dependency를 생성 및 주입하는 함수의 구현부를 작성해주세요.
   
   public func makeSampleSignInUsecase() -> SampleSignInUseCase {
-    return SignInUseCaseImpl(sampleAuthRepository: makeSampleAuthData())
+    return SampleSignInUseCaseImp(sampleAuthRepository: makeSampleAuthData())
   }
   
   public func makeSampleSignUpUsecase() -> SampleSignUpUseCase {
-    return SignUpUseCaseImpl(sampleAuthRepository: makeSampleAuthData())
+    return SampleSignUpUseCaseImp(sampleAuthRepository: makeSampleAuthData())
   }
   
   // MARK: - 추가되는 Feature에 따라 Presenter Dependency를 생성 및 주입하는 함수의 구현부를 작성해주세요.

--- a/WalWal/DependencyFactory/Interface/DependencyFactory.swift
+++ b/WalWal/DependencyFactory/Interface/DependencyFactory.swift
@@ -25,7 +25,6 @@ public protocol DependencyFactory {
   
   // MARK: - 추가되는 Feature에 따라 Dependency를 생성 및 주입하는 함수를 추가해주새요
   
-  /// Sample Features
   func makeSampleAuthData() -> SampleAuthRepository
   
   func makeSampleSignInUsecase() -> SampleSignInUseCase
@@ -38,11 +37,7 @@ public protocol DependencyFactory {
   func makeSplashViewController<T: SplashReactor>(reactor: T) -> any SplashViewController
   
   func makeAppCoordinator(navigationController: UINavigationController) -> any AppCoordinator
-
-  /// Sample Coordinaotrs
   func makeSampleAppCoordinator(navigationController: UINavigationController) -> any SampleAppCoordinator
-  
   func makeSampleAuthCoordinator(navigationController: UINavigationController, parentCoordinator: any BaseCoordinator) -> any SampleAuthCoordinator
-  
   func makeSampleHomeCoordinator(navigationController: UINavigationController, parentCoordinator: any BaseCoordinator) -> any SampleHomeCoordinator
 }

--- a/WalWal/DependencyFactory/Project.swift
+++ b/WalWal/DependencyFactory/Project.swift
@@ -27,27 +27,17 @@ let project = Project.invertedDualTargetProject(
     .WalWalNetwork.Interface,
     .WalWalNetwork.Implement,
     
-    .Coordinator.App.Interface,
     .Coordinator.App.Implement,
-    .Coordinator.SampleApp.Interface,
     .Coordinator.SampleApp.Implement,
-    .Coordinator.SampleAuth.Interface,
     .Coordinator.SampleAuth.Implement,
-    .Coordinator.SampleHome.Interface,
     .Coordinator.SampleHome.Implement,
     
     .Feature.Splash.Data.Implement,
-    .Feature.Splash.Data.Interface,
-    .Feature.Splash.Domain.Interface,
     .Feature.Splash.Domain.Implement,
-    .Feature.Splash.Presenter.Interface,
     .Feature.Splash.Presenter.Implement,
     
     .Feature.Sample.Data.Implement,
-    .Feature.Sample.Data.Interface,
-    .Feature.Sample.Domain.Interface,
     .Feature.Sample.Domain.Implement,
-    .Feature.Sample.Presenter.Interface,
     .Feature.Sample.Presenter.Implement
   ]
 )

--- a/WalWal/DependencyFactory/Project.swift
+++ b/WalWal/DependencyFactory/Project.swift
@@ -19,12 +19,11 @@ let project = Project.invertedDualTargetProject(
     .Coordinator.SampleAuth.Interface,
     .Coordinator.SampleHome.Interface,
     
-    .Feature.Sample.Data.Interface,
-    .Feature.Sample.Domain.Interface,
-    .Feature.Sample.Presenter.Interface
+    .Feature.Sample.Presenter.Interface,
+    
+    .Feature.Splash.Presenter.Interface
   ],
   implementDependencies: [
-    .WalWalNetwork.Interface,
     .WalWalNetwork.Implement,
     
     .Coordinator.App.Implement,

--- a/WalWal/DesignSystem/Project.swift
+++ b/WalWal/DesignSystem/Project.swift
@@ -38,8 +38,7 @@ let project = Project(
         .ThirdParty.RxGesture,
         .ThirdParty.Then,
         .ThirdParty.Kingfisher,
-        
-          .ResourceKit,
+        .ResourceKit,
       ]),
     Target(
       name: "DesignSystemDemoApp",

--- a/WalWal/DesignSystem/Project.swift
+++ b/WalWal/DesignSystem/Project.swift
@@ -33,8 +33,6 @@ let project = Project(
       dependencies: [
         .ThirdParty.PinLayout,
         .ThirdParty.FlexLayout,
-        .ThirdParty.RxCocoa,
-        .ThirdParty.RxSwift,
         .ThirdParty.RxGesture,
         .ThirdParty.Then,
         .ThirdParty.Kingfisher,
@@ -62,14 +60,7 @@ let project = Project(
       resources: ["./DemoApp/Resources/**"],
       dependencies:
         [
-          .target(name: "DesignSystem"),
-          .ThirdParty.FlexLayout,
-          .ThirdParty.PinLayout,
-          .ThirdParty.RxCocoa,
-          .ThirdParty.RxSwift,
-          .ThirdParty.RxGesture,
-          .ThirdParty.Then,
-          .ResourceKit
+          .target(name: "DesignSystem")
         ]
     )
   ]

--- a/WalWal/Features/Sample/SampleData/Project.swift
+++ b/WalWal/Features/Sample/SampleData/Project.swift
@@ -15,12 +15,9 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift
-  ],
-  implementDependencies: [
-    .ThirdParty.RxSwift,
     .WalWalNetwork.Interface
-  ]
+  ],
+  implementDependencies: []
 )
 
 

--- a/WalWal/Features/Sample/SampleDomain/Implement/SampleSignInUseCaseImp.swift
+++ b/WalWal/Features/Sample/SampleDomain/Implement/SampleSignInUseCaseImp.swift
@@ -1,5 +1,5 @@
 //
-//  SampleSignUpUseCaseImpl.swift
+//  SampleSignInUseCaseImp.swift
 //  SampleDomainImp
 //
 //  Created by 조용인 on 7/13/24.
@@ -12,7 +12,7 @@ import SampleDomain
 
 import RxSwift
 
-public final class SignUpUseCaseImpl: SampleSignUpUseCase {
+public final class SampleSignInUseCaseImp: SampleSignInUseCase {
   
   // MARK: - Properties
   
@@ -26,8 +26,8 @@ public final class SignUpUseCaseImpl: SampleSignUpUseCase {
   
   // MARK: - Methods
   
-  public func execute(nickname: String, profile: Data) -> Single<SampleToken> {
-    sampleAuthRepository.signUp(nickname: nickname, profile: profile)
+  public func execute(id: String, password: String) -> Single<SampleToken> {
+    sampleAuthRepository.signIn(id: id, password: password)
       .map { SampleTokenImp(dto: $0) }
   }
 }

--- a/WalWal/Features/Sample/SampleDomain/Implement/SampleSignUpUseCaseImp.swift
+++ b/WalWal/Features/Sample/SampleDomain/Implement/SampleSignUpUseCaseImp.swift
@@ -1,5 +1,5 @@
 //
-//  SampleSignInUseCaseImpl.swift
+//  SampleSignUpUseCaseImp.swift
 //  SampleDomainImp
 //
 //  Created by 조용인 on 7/13/24.
@@ -12,7 +12,7 @@ import SampleDomain
 
 import RxSwift
 
-public final class SignInUseCaseImpl: SampleSignInUseCase {
+public final class SampleSignUpUseCaseImp: SampleSignUpUseCase {
   
   // MARK: - Properties
   
@@ -26,8 +26,8 @@ public final class SignInUseCaseImpl: SampleSignInUseCase {
   
   // MARK: - Methods
   
-  public func execute(id: String, password: String) -> Single<SampleToken> {
-    sampleAuthRepository.signIn(id: id, password: password)
+  public func execute(nickname: String, profile: Data) -> Single<SampleToken> {
+    sampleAuthRepository.signUp(nickname: nickname, profile: profile)
       .map { SampleTokenImp(dto: $0) }
   }
 }

--- a/WalWal/Features/Sample/SampleDomain/Project.swift
+++ b/WalWal/Features/Sample/SampleDomain/Project.swift
@@ -16,13 +16,9 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift,
-  ],
-  implementDependencies: [
-    .ThirdParty.RxSwift,
-    
     .Feature.Sample.Data.Interface
-  ]
+  ],
+  implementDependencies: []
 )
 
 

--- a/WalWal/Features/Sample/SamplePresenter/DemoApp/Sources/SampleDemoAppDelegate.swift
+++ b/WalWal/Features/Sample/SamplePresenter/DemoApp/Sources/SampleDemoAppDelegate.swift
@@ -8,12 +8,7 @@
 
 import UIKit
 
-import DependencyFactory
 import DependencyFactoryImp
-import SampleData
-import SampleDomain
-import SampleAppCoordinator
-import SamplePresenter
 
 @main
 final class SampleAppDelegate: UIResponder, UIApplicationDelegate {

--- a/WalWal/Features/Sample/SamplePresenter/Project.swift
+++ b/WalWal/Features/Sample/SamplePresenter/Project.swift
@@ -15,10 +15,10 @@ let project = Project.invertedPresenterWithDemoApp(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift,
-    .ThirdParty.ReactorKit,
+    .Coordinator.SampleApp.Interface,
     
-    .Coordinator.SampleApp.Interface
+    .ThirdParty.RxSwift,
+    .ThirdParty.ReactorKit
   ],
   implementDependencies: [
     .ThirdParty.Then,

--- a/WalWal/Features/Sample/SamplePresenter/Project.swift
+++ b/WalWal/Features/Sample/SamplePresenter/Project.swift
@@ -16,7 +16,7 @@ let project = Project.invertedPresenterWithDemoApp(
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
     .ThirdParty.ReactorKit,
-//    .Coordinator.SampleApp.Interface,
+    
     .Feature.Sample.Domain.Interface
   ],
   implementDependencies: [

--- a/WalWal/Features/Sample/SamplePresenter/Project.swift
+++ b/WalWal/Features/Sample/SamplePresenter/Project.swift
@@ -15,28 +15,15 @@ let project = Project.invertedPresenterWithDemoApp(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .Coordinator.SampleApp.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.ReactorKit
+    .ThirdParty.ReactorKit,
+//    .Coordinator.SampleApp.Interface,
+    .Feature.Sample.Domain.Interface
   ],
   implementDependencies: [
-    .ThirdParty.Then,
-    .ThirdParty.FlexLayout,
-    .ThirdParty.PinLayout,
-    .ThirdParty.RxCocoa,
-    .ThirdParty.RxSwift,
-    .ThirdParty.ReactorKit,
-    
-    .Coordinator.SampleApp.Interface,
-    .Feature.Sample.Domain.Interface,
-    
-    .DesignSystem,
-    .ResourceKit
+    .DesignSystem
   ],
   demoAppDependencies: [
-    .DependencyFactory.Interface,
-    .DependencyFactory.Implement,
+    .DependencyFactory.Implement
   ]
 )
 

--- a/WalWal/Features/Splash/SplashData/Project.swift
+++ b/WalWal/Features/Splash/SplashData/Project.swift
@@ -15,12 +15,9 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift
-  ],
-  implementDependencies: [
-    .ThirdParty.RxSwift,
     .WalWalNetwork.Interface
-  ]
+  ],
+  implementDependencies: []
 )
 
 

--- a/WalWal/Features/Splash/SplashDomain/Project.swift
+++ b/WalWal/Features/Splash/SplashDomain/Project.swift
@@ -16,13 +16,9 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift,
-  ],
-  implementDependencies: [
-    .ThirdParty.RxSwift,
-    
     .Feature.Splash.Data.Interface
-  ]
+  ],
+  implementDependencies: []
 )
 
 

--- a/WalWal/Features/Splash/SplashPresenter/DemoApp/Sources/SplashDemoAppDelegate.swift
+++ b/WalWal/Features/Splash/SplashPresenter/DemoApp/Sources/SplashDemoAppDelegate.swift
@@ -8,12 +8,7 @@
 
 import UIKit
 
-import DependencyFactory
 import DependencyFactoryImp
-import SplashData
-import SplashDomain
-import SplashCoordinator
-import SplashPresenter
 
 @main
 final class SplashAppDelegate: UIResponder, UIApplicationDelegate {
@@ -23,7 +18,7 @@ final class SplashAppDelegate: UIResponder, UIApplicationDelegate {
     
     let dependencyFactory = DependencyFactoryImp()
     let navigationController = UINavigationController()
-    let coordinator = dependencyFactory.makeSplashCoordinator(navigationController: navigationController)
+    let coordinator = dependencyFactory.makeAppCoordinator(navigationController: navigationController)
     let reactor = dependencyFactory.makeSplashReactor(coordinator: coordinator)
     let viewController = dependencyFactory.makeSplashViewController(reactor: reactor)
     

--- a/WalWal/Features/Splash/SplashPresenter/Project.swift
+++ b/WalWal/Features/Splash/SplashPresenter/Project.swift
@@ -15,27 +15,14 @@ let project = Project.invertedPresenterWithDemoApp(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift,
     .ThirdParty.ReactorKit,
-    
-    .Coordinator.App.Interface
+//    .Coordinator.App.Interface,
+    .Feature.Splash.Domain.Interface
   ],
   implementDependencies: [
-    .ThirdParty.Then,
-    .ThirdParty.FlexLayout,
-    .ThirdParty.PinLayout,
-    .ThirdParty.RxCocoa,
-    .ThirdParty.RxSwift,
-    .ThirdParty.ReactorKit,
-    
-    .Coordinator.App.Interface,
-    .Feature.Splash.Domain.Interface,
-    
     .DesignSystem,
-    .ResourceKit
   ],
   demoAppDependencies: [
-    .DependencyFactory.Interface,
-    .DependencyFactory.Implement,
+    .DependencyFactory.Implement
   ]
 )

--- a/WalWal/Features/Splash/SplashPresenter/Project.swift
+++ b/WalWal/Features/Splash/SplashPresenter/Project.swift
@@ -16,11 +16,11 @@ let project = Project.invertedPresenterWithDemoApp(
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
     .ThirdParty.ReactorKit,
-//    .Coordinator.App.Interface,
+    
     .Feature.Splash.Domain.Interface
   ],
   implementDependencies: [
-    .DesignSystem,
+    .DesignSystem
   ],
   demoAppDependencies: [
     .DependencyFactory.Implement

--- a/WalWal/Plugins/TemplatePlugin/Templates/Coordinators/CoordinatorProject.stencil
+++ b/WalWal/Plugins/TemplatePlugin/Templates/Coordinators/CoordinatorProject.stencil
@@ -15,16 +15,9 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .Coordinator.Base.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .Coordinator.Base.Interface
   ],
   implementDependencies: [
-    .Coordinator.Base.Interface,
-    .DependencyFactory.Interface,
-    
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
+    .DependencyFactory.Interface
   ]
 )

--- a/WalWal/Plugins/TemplatePlugin/Templates/Feature/DataProject.stencil
+++ b/WalWal/Plugins/TemplatePlugin/Templates/Feature/DataProject.stencil
@@ -15,12 +15,9 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift
-  ],
-  implementDependencies: [
-    .ThirdParty.RxSwift,
     .WalWalNetwork.Interface
-  ]
+  ],
+  implementDependencies: []
 )
 
 

--- a/WalWal/Plugins/TemplatePlugin/Templates/Feature/DomainProject.stencil
+++ b/WalWal/Plugins/TemplatePlugin/Templates/Feature/DomainProject.stencil
@@ -16,13 +16,9 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift,
-  ],
-  implementDependencies: [
-    .ThirdParty.RxSwift,
-    
     .Feature.{{name}}.Data.Interface
-  ]
+  ],
+  implementDependencies: []
 )
 
 

--- a/WalWal/Plugins/TemplatePlugin/Templates/Feature/PresenterProject.stencil
+++ b/WalWal/Plugins/TemplatePlugin/Templates/Feature/PresenterProject.stencil
@@ -15,27 +15,14 @@ let project = Project.invertedPresenterWithDemoApp(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxSwift,
     .ThirdParty.ReactorKit,
     
-    .Coordinator.{{name}}.Interface
+    .Feature.{{name}}.Domain.Interface,
   ],
   implementDependencies: [
-    .ThirdParty.Then,
-    .ThirdParty.FlexLayout,
-    .ThirdParty.PinLayout,
-    .ThirdParty.RxCocoa,
-    .ThirdParty.RxSwift,
-    .ThirdParty.ReactorKit,
-    
-    .Coordinator.{{name}}.Interface,
-    .Feature.{{name}}.Domain.Interface,
-    
-    .DesignSystem,
-    .ResourceKit
+    .DesignSystem
   ],
   demoAppDependencies: [
-    .DependencyFactory.Interface,
-    .DependencyFactory.Implement,
+    .DependencyFactory.Implement
   ]
 )

--- a/WalWal/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/WalWal/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -151,8 +151,8 @@ extension Project {
       sources: ["./DemoApp/Sources/**"],
       resources: ["./DemoApp/Resources/**"],
       dependencies: [
-        .target(name: "\(name)"),
-        .target(name: "\(name)Imp"),
+//        .target(name: "\(name)"),
+//        .target(name: "\(name)Imp"),
       ] + demoAppDependencies
     )
     

--- a/WalWal/Utility/Project.swift
+++ b/WalWal/Utility/Project.swift
@@ -31,15 +31,7 @@ let project = Project(
       infoPlist: .default,
       sources: ["Sources/**"],
       dependencies: [
-        .ThirdParty.PinLayout,
-        .ThirdParty.FlexLayout,
-        .ThirdParty.RxCocoa,
-        .ThirdParty.RxSwift,
-        .ThirdParty.RxGesture,
-        .ThirdParty.Then,
-        .ThirdParty.Kingfisher,
-        
-        .ResourceKit,
+        .ThirdParty.RxCocoa
       ]
     ),
   ]

--- a/WalWal/WalWalNetwork/Project.swift
+++ b/WalWal/WalWalNetwork/Project.swift
@@ -14,12 +14,7 @@ let project = Project.invertedDualTargetProject(
   platform: .iOS,
   iOSTargetVersion: "15.0.0",
   interfaceDependencies: [
-    .ThirdParty.RxAlamofire,
-    .ThirdParty.RxSwift
+    .ThirdParty.RxAlamofire
   ],
-  implementDependencies: [
-    .ThirdParty.RxAlamofire,
-    .ThirdParty.RxSwift,
-    .ThirdParty.RxCocoa
-  ]
+  implementDependencies: []
 )


### PR DESCRIPTION
## 📌 개요
기존의 복잡하게 얽혀있는 의존성 관리를, 보다 효과적으로 관리할 수 있게 변경
## ✍️ 변경사항
각 모듈별로, 필수로 필요하지 않는 Dependency에 대해 제거 및 이후에 추가될 모듈을 위한 Template 수정

코드 로직상으로는 큰 변경은 없으나, 내부 모듈에서 실제로 갖게 되는 Dependency에 관하여 많은 수정이 있었습니다.
우선, 현재 코드 상태에서 WalWal / SplashDemoApp / SampleDemoApp 모두 정상 빌드가 되는것을 확인 하였으나,
실제 Auth로직이 포함되어있는 코드에도 동일한 Dependency구조를 적용했을 때, 정상 동작이 되는지 확인이 필요합니다.
## 📷 스크린샷
### 기존의 Dependency 구조
![기존 Dependency 구조](https://github.com/user-attachments/assets/bae58007-4517-4177-be0c-fa0006e45c99)

### 변경된 Dependency 구조
![변경된 Dependency 구조](https://github.com/user-attachments/assets/6eba1c93-1add-4183-a9f0-8c24ae9d9201)

## 🛠️ **Technical Concerns(기술적 고민)**
이번 작업을 하면서, 전체 모듈의 의존성 주입 구조를 다시한번 고민하게 되었습니다.
특히, `DependencyFactory`의 구조를 `Feature`별로 별도의 **Module**로 구현하고자 시도를 하였지만,
특정 Coordinator내부에서, 별도의 Flow를 시작하게 되는 경우에는 해당 Flow를 소유한 DependencyFactory를 또다시 주입해줘야하는 상확이 발생하였습니다.
그래서 `Feature`별로 `DependencyFactory`를 분리하여 설계하는것이 큰 의미가 없을 것이라 생각하여, 하나의 `DependencyFactory`를 갖는 구조로 진행하게 되었습니다.

