### PR TITLE
image Upload 함수 구현

### DIFF
--- a/WalWal/Features/Auth/AuthData/Implement/Endpoint/AuthEndpoint.swift
+++ b/WalWal/Features/Auth/AuthData/Implement/Endpoint/AuthEndpoint.swift
@@ -18,10 +18,6 @@ enum AuthEndpoint<T>: APIEndpoint where T: Decodable {
 }
 
 extension AuthEndpoint {
-  var baseURL: URL {
-    return URL(string: "")!
-  }
-  
   var path: String {
     switch self {
     case .appleLogin:
@@ -43,12 +39,10 @@ extension AuthEndpoint {
     }
   }
   
-  var headers: WalWalHTTPHeader {
+  var headerType: HTTPHeaderType {
     switch self {
     case .appleLogin:
-      return [
-        "Content-Type": "application/json"
-      ]
+      return .plain
     }
   }
 }

--- a/WalWal/Features/Auth/AuthData/Implement/Endpoint/AuthEndpoint.swift
+++ b/WalWal/Features/Auth/AuthData/Implement/Endpoint/AuthEndpoint.swift
@@ -18,6 +18,13 @@ enum AuthEndpoint<T>: APIEndpoint where T: Decodable {
 }
 
 extension AuthEndpoint {
+  var baseURLType: URLType {
+     switch self {
+     case .appleLogin(_):
+       return .walWalBaseURL
+     }
+   }
+  
   var path: String {
     switch self {
     case .appleLogin:

--- a/WalWal/Features/Sample/SampleData/Implement/Endpoint/SampleAuthEndpoint.swift
+++ b/WalWal/Features/Sample/SampleData/Implement/Endpoint/SampleAuthEndpoint.swift
@@ -20,10 +20,6 @@ enum AuthEndpoint<ResponseType>: APIEndpoint where ResponseType: Decodable {
 }
 
 extension AuthEndpoint {
-  var baseURL: URL {
-    return URL(string: "")!
-  }
-  
   var path: String {
     switch self {
     case .signIn:
@@ -51,18 +47,12 @@ extension AuthEndpoint {
     }
   }
   
-  var headers: WalWalHTTPHeader {
+  var headerType: HTTPHeaderType {
     switch self {
     case .signIn:
-      return [
-        "Content-Type": "application/json"
-      ]
+        .plain
     case .signUp:
-      return [
-        // 회원가입에는 Data타입이랑 같이 보내기 위해서 Presigned-Url 머시기 헤더에 dataform관련해서 올라가지 않을까
-        "Content-Type": "application/json"
-      ]
+        .plain
     }
   }
-  
 }

--- a/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
@@ -37,7 +37,7 @@ public enum RequestParams {
   case requestQuery(_ parameter: Encodable?)
   case requestWithbody(_ parameter: Encodable?)
   case requestQueryWithBody(_ queryParameter: Encodable?, _ bodyParameter: Encodable?)
-  case uploadImage
+  case upload
 }
 
 /// HTTP Header를 상수처럼 사용하기 위해 정의한 Type

--- a/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
@@ -17,6 +17,16 @@ public protocol APIEndpoint: URLRequestConvertible {
   var headerType: HTTPHeaderType { get }
 }
 
+/// 통신을 보낼 URL을 선택하는 enum 값 입니다.
+/// S3 image 업로드 시에는 .presignedURL, 나머지에서는 .walWalBaseURL
+///
+/// 사용 예시
+/// ``` swift
+///     case .loadImagePresignedURL(_): // Presigned URL을 우리 서버에 요청
+///       return .walWalBaseURL
+///     case let .uploadImage(url): // S3 Bucket에 이미지 업로드
+///       return .presignedURL(url)
+///  ```
 public enum URLType {
   case walWalBaseURL
   case presignedURL(String)
@@ -30,6 +40,7 @@ public enum RequestParams {
   case uploadImage
 }
 
+/// HTTP Header를 상수처럼 사용하기 위해 정의한 Type
 enum HTTPHeaderFieldKey : String {
   case authentication = "Authorization"
   case contentType = "Content-Type"
@@ -40,6 +51,16 @@ enum HTTPHeaderFieldValue: String {
     case accessToken
 }
 
+/// HTTP Header 설정 enum입니다.
+/// 추후 헤더에 다른 값을 넣게 된다면 case를 추가
+///
+/// 사용 예시
+/// ``` swift
+///     case .loadImagePresignedURL(_): // Presigned URL을 우리 서버에 요청
+///       return .authorization("토큰값")
+///     case let .uploadImage(url): // S3 Bucket에 이미지 업로드
+///       return .plain
+///  ```
 public enum HTTPHeaderType {
   case plain
   case authorization(String)

--- a/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
@@ -27,7 +27,7 @@ public enum RequestParams {
   case requestQuery(_ parameter: Encodable?)
   case requestWithbody(_ parameter: Encodable?)
   case requestQueryWithBody(_ queryParameter: Encodable?, _ bodyParameter: Encodable?)
-  case uploadMultipart([MultipartFormData])
+  case uploadImage
 }
 
 enum HTTPHeaderFieldKey : String {

--- a/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpoint.swift
@@ -10,11 +10,16 @@ public typealias WalWalHTTPHeader = [String: String]
 public protocol APIEndpoint: URLRequestConvertible {
   associatedtype ResponseType: Decodable
   
-  var baseURL: URL { get }
+  var baseURLType: URLType { get }
   var path: String { get }
   var method: HTTPMethod { get }
   var parameters: RequestParams { get }
   var headerType: HTTPHeaderType { get }
+}
+
+public enum URLType {
+  case walWalBaseURL
+  case presignedURL(String)
 }
 
 public enum RequestParams {

--- a/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
@@ -49,7 +49,7 @@ public extension APIEndpoint {
     case .requestQueryWithBody(let query, let body):
       urlRequest.url = try configureQueryParams(url: url, query: query)
       urlRequest.httpBody = try configureBodyParams(body: body)
-    case .uploadImage:
+    case .upload:
       break
     }
     return urlRequest

--- a/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
@@ -1,0 +1,82 @@
+//
+//  APIEndpointImp.swift
+//  WalWalNetwork
+//
+//  Created by 이지희 on 7/30/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+public extension APIEndpoint {
+  var baseURL: URL {
+    return URL(string: "")!
+  }
+  
+  var headers: WalWalHTTPHeader {
+    switch headerType {
+    case .plain:
+      return [
+        HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue
+      ]
+    case .authorization(let token):
+      return [
+        HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
+        HTTPHeaderFieldKey.authentication.rawValue: "Bearer \(token)"
+      ]
+    }
+  }
+  
+  func asURLRequest() throws -> URLRequest {
+    let url = try configureURL(baseURL)
+    var urlRequest = try URLRequest(url: url, method: method)
+    urlRequest = configureHeader(urlRequest)
+    
+    switch parameters {
+    case .requestPlain:
+      break
+    case .requestQuery(let query):
+      urlRequest.url = try configureQueryParams(url: url, query: query)
+    case .requestWithbody(let body):
+      urlRequest.httpBody = try configureBodyParams(body: body)
+    case .requestQueryWithBody(let query, let body):
+      urlRequest.url = try configureQueryParams(url: url, query: query)
+      urlRequest.httpBody = try configureBodyParams(body: body)
+    case .uploadMultipart(_):
+      break
+    }
+    return urlRequest
+  }
+  
+  private func configureURL(_ url: URL) throws -> URL {
+    let baseURL = try baseURL.asURL()
+    let url = baseURL.appendingPathComponent(path)
+    return url
+  }
+  
+  private func configureHeader(_ urlRequest: URLRequest) -> URLRequest {
+    var urlRequest = urlRequest
+    for (headerField, headerValue) in headers {
+      urlRequest.setValue(headerValue, forHTTPHeaderField: headerField)
+    }
+    return urlRequest
+  }
+  
+  private func configureQueryParams(url: URL, query: Encodable?) throws -> URL {
+    let params = query?.toDictionary() ?? [:]
+    let queryParams = params.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+    var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    components?.queryItems = queryParams
+    guard let configuredURL = components?.url else {
+      throw URLError(.badURL)
+    }
+    return configuredURL
+  }
+  
+  private func configureBodyParams(body: Encodable?) throws -> Data {
+    let params = body?.toDictionary() ?? [:]
+    return try JSONSerialization.data(withJSONObject: params, options: [])
+  }
+}

--- a/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
@@ -14,7 +14,7 @@ public extension APIEndpoint {
   var baseURL: URL {
     switch baseURLType {
     case .walWalBaseURL:
-      return URL(string: "")!
+      return URL(string: "")! // TODO: Config의 BaseURL
     case .presignedURL(let string):
       return URL(string: string)!
     }

--- a/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
@@ -12,7 +12,12 @@ import Alamofire
 
 public extension APIEndpoint {
   var baseURL: URL {
-    return URL(string: "")!
+    switch baseURLType {
+    case .walWalBaseURL:
+      return URL(string: "")!
+    case .presignedURL(let string):
+      return URL(string: string)!
+    }
   }
   
   var headers: WalWalHTTPHeader {

--- a/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
+++ b/WalWal/WalWalNetwork/Sources/APIEndpointImp.swift
@@ -49,7 +49,7 @@ public extension APIEndpoint {
     case .requestQueryWithBody(let query, let body):
       urlRequest.url = try configureQueryParams(url: url, query: query)
       urlRequest.httpBody = try configureBodyParams(body: body)
-    case .uploadMultipart(_):
+    case .uploadImage:
       break
     }
     return urlRequest

--- a/WalWal/WalWalNetwork/Sources/NetworkService.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkService.swift
@@ -18,4 +18,5 @@ public protocol NetworkServiceProtocol {
   /// request(:) 메서드는 APIEndpoint 프로토콜을 준수하는 엔드포인트를 받아 Single<T> 타입의 Observable을 반환합니다.
   /// 공통되는 엔티티를 사용하기 위해 BaseResponse를 사용합니다.
   func request<E: APIEndpoint>(endpoint: E) -> Single<E.ResponseType?> where E: APIEndpoint
+  func upload<E: APIEndpoint> (endpoint: E, image: UIImage) -> Single<Bool> where E: APIEndpoint
 }

--- a/WalWal/WalWalNetwork/Sources/NetworkService.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkService.swift
@@ -18,5 +18,5 @@ public protocol NetworkServiceProtocol {
   /// request(:) 메서드는 APIEndpoint 프로토콜을 준수하는 엔드포인트를 받아 Single<T> 타입의 Observable을 반환합니다.
   /// 공통되는 엔티티를 사용하기 위해 BaseResponse를 사용합니다.
   func request<E: APIEndpoint>(endpoint: E) -> Single<E.ResponseType?> where E: APIEndpoint
-  func upload<E: APIEndpoint> (endpoint: E, image: UIImage) -> Single<Bool> where E: APIEndpoint
+  func upload<E: APIEndpoint> (endpoint: E, imageData: Data) -> Single<Bool> where E: APIEndpoint
 }

--- a/WalWal/WalWalNetwork/Sources/NetworkService.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkService.swift
@@ -19,8 +19,3 @@ public protocol NetworkServiceProtocol {
   /// 공통되는 엔티티를 사용하기 위해 BaseResponse를 사용합니다.
   func request<E: APIEndpoint>(endpoint: E) -> Single<E.ResponseType?> where E: APIEndpoint
 }
-
-public enum UploadData {
-  case file(data: Data, name: String, fileName: String, mimeType: String)
-  case parameter(name: String, value: String)
-}

--- a/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
@@ -23,8 +23,6 @@ public final class NetworkService: NetworkServiceProtocol {
   }
   
   public func request<E: APIEndpoint>(endpoint: E) -> Single<E.ResponseType?> where E: APIEndpoint {
-    let url = endpoint.baseURL.appendingPathComponent(endpoint.path)
-    let headers = HTTPHeaders(endpoint.headers)
     requestLogging(endpoint)
     /// 추후에 interceptor 추가 가능
     return RxAlamofire.requestJSON(endpoint)
@@ -56,12 +54,10 @@ public final class NetworkService: NetworkServiceProtocol {
   /// networkService.upload(endpoint, imageData: imageData)
   /// ```
   public func upload<E: APIEndpoint> (endpoint: E, imageData: Data) -> Single<Bool> where E: APIEndpoint{
-    let url = endpoint.baseURL
-    let headers = HTTPHeaders(endpoint.headers)
     requestLogging(endpoint)
     
     return Single.create { single -> Disposable in
-      AF.upload(imageData, to: url, method: endpoint.method, headers: headers)
+      AF.upload(imageData, with: endpoint)
         .validate(statusCode: 200...299)
         .responseData(emptyResponseCodes: [200]) { response in
           switch response.result {

--- a/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
@@ -47,7 +47,15 @@ public final class NetworkService: NetworkServiceProtocol {
   }
   
   // MARK: - Image Upload
-  func upload<E: APIEndpoint> (endpoint: E, image: UIImage) -> Single<Bool> where E: APIEndpoint{
+  
+  /// 이미지를 Presigned URL로 업로드 하는 함수입니다.
+  /// UIImage를 인자로 받아 함수 내에서 BinaryData 타입으로 변환합니다.
+  ///
+  /// 사용 예시
+  /// ``` swift
+  ///
+  /// ```
+  public func upload<E: APIEndpoint> (endpoint: E, image: UIImage) -> Single<Bool> where E: APIEndpoint{
     let url = endpoint.baseURL
     let headers = HTTPHeaders(endpoint.headers)
     requestLogging(endpoint)

--- a/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
@@ -63,7 +63,7 @@ public final class NetworkService: NetworkServiceProtocol {
     return Single.create { single -> Disposable in
       AF.upload(imageData, to: url, method: endpoint.method, headers: headers)
         .validate(statusCode: 200...299)
-        .responseData(emptyResponseCodes: [200, 204]) { response in
+        .responseData(emptyResponseCodes: [200]) { response in
           switch response.result {
           case .success(_):
             single(.success(true))

--- a/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
@@ -27,10 +27,7 @@ public final class NetworkService: NetworkServiceProtocol {
     let headers = HTTPHeaders(endpoint.headers)
     requestLogging(endpoint)
     /// 추후에 interceptor 추가 가능
-    return RxAlamofire.requestJSON(endpoint.method,
-                                   url,
-                                   parameters: parametersToDictionary(endpoint.parameters),
-                                   headers: headers)
+    return RxAlamofire.requestJSON(endpoint)
     .map{ response, anyData -> (HTTPURLResponse, Data) in
       let convertedData = try JSONSerialization.data(withJSONObject: anyData)
       return (response, convertedData)

--- a/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
@@ -49,20 +49,16 @@ public final class NetworkService: NetworkServiceProtocol {
   // MARK: - Image Upload
   
   /// 이미지를 Presigned URL로 업로드 하는 함수입니다.
-  /// UIImage를 인자로 받아 함수 내에서 BinaryData 타입으로 변환합니다.
   ///
   /// 사용 예시
   /// ``` swift
-  ///
+  /// let imageData = image.jpegData(compressionQuality: 0.8)! // UIImage -> jpegData
+  /// networkService.upload(endpoint, imageData: imageData)
   /// ```
-  public func upload<E: APIEndpoint> (endpoint: E, image: UIImage) -> Single<Bool> where E: APIEndpoint{
+  public func upload<E: APIEndpoint> (endpoint: E, imageData: Data) -> Single<Bool> where E: APIEndpoint{
     let url = endpoint.baseURL
     let headers = HTTPHeaders(endpoint.headers)
     requestLogging(endpoint)
-    
-    guard let imageData = image.jpegData(compressionQuality: 0.8) else {
-      return Single.error(WalWalNetworkError.invalidRequest)
-    }
     
     return Single.create { single -> Disposable in
       AF.upload(imageData, to: url, method: endpoint.method, headers: headers)

--- a/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift
@@ -145,7 +145,7 @@ extension NetworkService {
         .requestWithbody(let parameter),
         .requestQueryWithBody(_, let parameter):
       return parameter?.toDictionary()
-    case .uploadMultipart:
+    case .uploadImage:
       return nil
     }
   }


### PR DESCRIPTION
## 📌 개요
S3 Presigned URL을 이용한 이미지 업로드를 위한 이미지 업로드 함수를 구현했습니다. 

## ✍️ 변경사항
### 이미지 업로드 과정
![Frame 1739333532](https://github.com/user-attachments/assets/db523cd2-13be-4d01-a71e-8d169c482e47)
```
전체적인 플로우 
1. 클라 -> 서버로 사진 업로드 URL 요청하면 URL과 Key 받음
2. 클라 -> S3 URL로 PUT 요청 Binary File 첨부, 업로드 요청
3. S3에게 200 OK를 받으면 업로드 성공
4. 클라 -> 서버 닉네임, 사진 형식(JPEG) 서버로 POST -> 200 OK 
```
이미지 통신과 관련된 API 통신들은 Image 모듈을 따로 만들어서 여러 곳에서 재사용할 수 있게 만들 예정입니다. 
RxAlamofire에는 URL 또는 MultipartForm을 업로드 하는 함수만 존재하여 Data 타입 업로드를 위해 AF.upload()를 사용했습니다. Single<Bool> 형식으로 반환합니다! 더 좋은 방법이 있다면 말씀해주세요
https://github.com/depromeet/WalWal-iOS/blob/b406733fc5e1998edd8425e00213e276ec6f0166/WalWal/WalWalNetwork/Sources/NetworkServiceImp.swift#L64-L74

### Endpoint 간소화
#### AS-IS 
이전 Endpoint 는 BaseURL과 Header를 반복해서 하드코딩해야 하는 단점이 있었습니다. 
#### TO-BE
다음과 같은 enum 타입을 정의하여 Endpoint 작성을 편리하게 수정하였습니다. presigned url을 받아 넣어야하는 경우가 있어서 baseURL도 두가지로 나뉩니다. 
``` swift 
/// HTTP Header를 상수처럼 사용하기 위해 정의한 Type
enum HTTPHeaderFieldKey : String {
  case authentication = "Authorization"
  case contentType = "Content-Type"
}

enum HTTPHeaderFieldValue: String {
    case json = "Application/json"
    case accessToken
}
```
### request함수 오류 수정
기존 request 함수를 이용하여 통신 시 통신 오류가 발생하여 수정하였습니다. 

## 🛠️ **Technical Concerns(기술적 고민)**
### 이미지 관련 Data Module
<img width="645" alt="image" src="https://github.com/user-attachments/assets/5e3fe9fe-c8d4-439a-8a14-fcda4a4f7a9e">

이미지 업로드는 미션 인증 이미지, 프로필 이미지 등록/변경 시 사용되게 됩니다(Auth, Mission, Profile). 때문에 여러 Repository에서 공통된 API를 통신 할 것 같은데 이런 경우 Data, Domain 을 어떻게 배치할지 고민입니다! 
