### PR TITLE
interceptor, request 함수 리팩토링

### DIFF
--- a/WalWal/Features/Auth/AuthData/Implement/Repository/AuthRepositoryImp.swift
+++ b/WalWal/Features/Auth/AuthData/Implement/Repository/AuthRepositoryImp.swift
@@ -23,7 +23,7 @@ public final class AuthRepositoryImp: AuthRepository {
   public func socialLogin(provider: String, token: String) -> Single<AuthTokenDTO> {
     let body = SocialLoginBody(token: token)
     let endPoint = AuthEndpoint<AuthTokenDTO>.socialLogin(provider: provider, body: body)
-    return networkService.request(endpoint: endPoint)
+    return networkService.request(endpoint: endPoint, isNeedInterceptor: false)
       .compactMap{ $0 }
       .asObservable()
       .asSingle()

--- a/WalWal/Features/Mission/MissionData/Implement/Repository/MissionRepositoryImp.swift
+++ b/WalWal/Features/Mission/MissionData/Implement/Repository/MissionRepositoryImp.swift
@@ -22,7 +22,7 @@ public final class MissionRepositoryImp: MissionRepository {
   
   public func loadMissionInfo() -> Single<MissionInfoDTO> {
     let endpoint = MissionEndpoint<MissionInfoDTO>.loadMissionInfo
-    return networkService.request(endpoint: endpoint)
+    return networkService.request(endpoint: endpoint, isNeedInterceptor: true)
       .compactMap { $0 }
       .asObservable()
       .asSingle()

--- a/WalWal/Features/Sample/SampleData/Implement/Repositories/SampleAuthRepositoryImp.swift
+++ b/WalWal/Features/Sample/SampleData/Implement/Repositories/SampleAuthRepositoryImp.swift
@@ -32,12 +32,12 @@ public final class SampleAuthRepositoryImp: SampleAuthRepository {
   public func signUp(nickname: String, profile: Data) -> Single<SampleSignUpDTO> {
     let body = SampleSignUpBody(nickname: nickname, profile: profile)
     let endpoint = AuthEndpoint<SampleSignUpDTO>.signUp(body: body)
-    return networkService.request(endpoint: endpoint).compactMap{ $0 }.asObservable().asSingle()
+    return networkService.request(endpoint: endpoint, isNeedInterceptor: false).compactMap{ $0 }.asObservable().asSingle()
   }
   
   public func signIn(id: String, password: String) -> Single<SampleSignInDTO> {
     let body = SampleSignInBody(id: id, password: password)
     let endpoint = AuthEndpoint<SampleSignInDTO>.signIn(body: body)
-    return networkService.request(endpoint: endpoint).compactMap{ $0 }.asObservable().asSingle()
+    return networkService.request(endpoint: endpoint, isNeedInterceptor: false).compactMap{ $0 }.asObservable().asSingle()
   }
 }

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkError.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkError.swift
@@ -17,6 +17,7 @@ public enum WalWalNetworkError: Error {
   case serverError(statusCode: Int)
   case decodingError(Error)
   case tokenReissueFailed
+  case retryExceeded(Error)
   case unknown(Error)
 }
 
@@ -33,6 +34,8 @@ extension WalWalNetworkError: LocalizedError {
       return "네트워크 오류입니다 \(code)"
     case .tokenReissueFailed:
       return "토큰 재발급에 실패했습니다. 다시 로그인해주세요."
+    case .retryExceeded(let error):
+      return "retry 횟수 초과입니다. \(error)"
     case .unknown(let error):
       return "알 수 없는 에러 입니다. : \(error)"
     }

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkService.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkService.swift
@@ -17,6 +17,9 @@ import RxSwift
 public protocol NetworkServiceProtocol {
   /// request(:) 메서드는 APIEndpoint 프로토콜을 준수하는 엔드포인트를 받아 Single<T> 타입의 Observable을 반환합니다.
   /// 공통되는 엔티티를 사용하기 위해 BaseResponse를 사용합니다.
-  func request<E: APIEndpoint>(endpoint: E) -> Single<E.ResponseType?> where E: APIEndpoint
+  /// - Parameters:
+  /// - `endpoint` : APIEndpoint enum
+  /// - `isNeedInterceptor` : interceptor를 통한 토큰 유효성 검사가 필요할 경우 true 
+  func request<E: APIEndpoint>(endpoint: E, isNeedInterceptor: Bool) -> Single<E.ResponseType?> where E: APIEndpoint
   func upload<E: APIEndpoint> (endpoint: E, imageData: Data) -> Single<Bool> where E: APIEndpoint
 }

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
@@ -22,7 +22,7 @@ public final class NetworkService: NetworkServiceProtocol {
     
   }
   
-  public func request<E: APIEndpoint>(endpoint: E) -> Single<E.ResponseType?> where E: APIEndpoint {
+  public func request<E: APIEndpoint>(endpoint: E, isNeedInterceptor: Bool = true) -> Single<E.ResponseType?> where E: APIEndpoint {
     requestLogging(endpoint)
     return RxAlamofire.requestJSON(endpoint, interceptor: WalwalInterceptor())
       .do(onError: { error in

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
@@ -24,7 +24,7 @@ public final class NetworkService: NetworkServiceProtocol {
   
   public func request<E: APIEndpoint>(endpoint: E, isNeedInterceptor: Bool = true) -> Single<E.ResponseType?> where E: APIEndpoint {
     requestLogging(endpoint)
-    return RxAlamofire.requestJSON(endpoint, interceptor: WalwalInterceptor())
+    return RxAlamofire.requestJSON(endpoint, interceptor: isNeedInterceptor ? WalwalInterceptor() : nil)
       .map { response, anyData -> (HTTPURLResponse, Data) in
         let convertedData = try JSONSerialization.data(withJSONObject: anyData)
         return (response, convertedData)

--- a/WalWal/WalWalNetwork/Sources/Foundation/WalwalInterceptor.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/WalwalInterceptor.swift
@@ -58,9 +58,12 @@ final public class WalwalInterceptor: RequestInterceptor {
           completion(.doNotRetryWithError(WalWalNetworkError.tokenReissueFailed))
         }
       }
-    } else if statusCode == 404 {
-      /// 유저를 찾을 수 없는 상태
-      completion(.doNotRetry)
+      else if statusCode == 404 {
+        /// 유저를 찾을 수 없는 상태
+        completion(.retry)
+      } else {
+        completion(.doNotRetry)
+      }
     }
   }
 }

--- a/WalWal/WalWalNetwork/Sources/Foundation/WalwalInterceptor.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/WalwalInterceptor.swift
@@ -62,7 +62,7 @@ final public class WalwalInterceptor: RequestInterceptor {
         /// 유저를 찾을 수 없는 상태
         completion(.retry)
       } else {
-        completion(.doNotRetry)
+        completion(.doNotRetryWithError(error))
       }
     }
   }

--- a/WalWal/WalWalNetwork/Sources/Reissue/ReissueEndpoint.swift
+++ b/WalWal/WalWalNetwork/Sources/Reissue/ReissueEndpoint.swift
@@ -34,7 +34,7 @@ extension ReissueEndpoint {
   var method: HTTPMethod {
     switch self {
     case .reissue:
-      return .get
+      return .post
     }
   }
   
@@ -48,7 +48,7 @@ extension ReissueEndpoint {
   var headerType: HTTPHeaderType {
     switch self {
     case .reissue:
-      return .authorization("")
+      return .plain
     }
   }
 }


### PR DESCRIPTION
## 📌 개요
interceptor와 request에서 에러 핸들링 및 리펙토링을 진행했습니다. 

## ✍️ 변경사항
기존에 기본적으로 모두 인터셉터가 모두 관여했으니, `isNeedInterceptor` 파라미터로 구분하여 인터셉터가 필요할 때만 인터셉터를 넣어주었습니다. 소셜 로그인 시에는 false 해주시면 됩니다!

임의로 만료된 토큰을 넣어 테스트 완료했습니다. 리프레쉬 토큰이 아예 없는 경우 혹은 리프레쉬 토큰이 올바르지 않을 때는 500이 발생하여 retry 실패로 에러가 발생합니다 -> 추후 로그인 화면으로 이동 로직 필요

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/fa3ca713-686f-4226-a1a3-7855f9a931cc)

## 🛠️ **Technical Concerns(기술적 고민)**
에러 처리 과정에서 임의로 발생 시킬 수 있는 에러가 한정적이라 서버를 붙인 후 정상 플로우에서 발생하는 에러 핸들링을 추가해야 할 여지가 있습니다! 에러 처리 부분 피드백 주신 대로 수정 되었는지 확인 부탁드립니당 ~ @ji-yeon224 
