### PR TITLE
이미지 업로드 함수 버그 수정

### DIFF
--- a/WalWal/WalWalNetwork/Sources/Base/APIEndpoint.swift
+++ b/WalWal/WalWalNetwork/Sources/Base/APIEndpoint.swift
@@ -47,8 +47,9 @@ enum HTTPHeaderFieldKey : String {
 }
 
 enum HTTPHeaderFieldValue: String {
-    case json = "Application/json"
-    case accessToken
+  case json = "Application/json"
+  case accessToken
+  case jpeg = "image/jpeg"
 }
 
 /// HTTP Header 설정 enum입니다.
@@ -64,6 +65,7 @@ enum HTTPHeaderFieldValue: String {
 public enum HTTPHeaderType {
   case plain
   case authorization(String)
+  case uploadJPEG
 }
 
 extension Encodable {

--- a/WalWal/WalWalNetwork/Sources/Base/APIEndpointImp.swift
+++ b/WalWal/WalWalNetwork/Sources/Base/APIEndpointImp.swift
@@ -31,6 +31,10 @@ public extension APIEndpoint {
         HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
         HTTPHeaderFieldKey.authentication.rawValue: "Bearer \(token)"
       ]
+    case .uploadJPEG:
+      return [
+        HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.jpeg.rawValue
+      ]
     }
   }
   

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
@@ -60,9 +60,12 @@ public final class NetworkService: NetworkServiceProtocol {
   /// ```
   public func upload<E: APIEndpoint> (endpoint: E, imageData: Data) -> Single<Bool> where E: APIEndpoint{
     requestLogging(endpoint)
-    
+    let headers: HTTPHeaders = HTTPHeaders(endpoint.headers)
     return Single.create { single -> Disposable in
-      AF.upload(imageData, with: endpoint)
+      AF.upload(imageData,
+                to: endpoint.baseURL,
+                method: .put,
+                headers: headers)
         .validate(statusCode: 200...299)
         .responseData(emptyResponseCodes: [200]) { response in
           switch response.result {


### PR DESCRIPTION
## 📌 개요
이미지 업로드 시 발생하는 오류를 해결했습니다. 

## ✍️ 변경사항
#### 이미지 업로드 HeadeType 추가
- JPEG 형식의 이미지를 업로드할 때 `Content-Type`을 `image.jpeg`로 설정하는 헤더가 필요하여 추가했습니다. 
#### 이미지 업로드 함수 오류
- URLConvertible를 이용하는 upload 함수에서 Header와 method가 설정되지 않아 이미지 업로드 오류가 발생하는 걸 확인했습니다. 
- 이를 해결하기 위해 endpoint의 header와 method를 직접 설정해주는 식으로 변경했습니다.  요청은 그대로 Endpoint 만들어서 넣어주시면 됩니다!
https://github.com/depromeet/WalWal-iOS/blob/e248f8f6414b8668fef936bf966d8a42f064923c/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift#L65-L68
### 에러 핸들링 
200대 이외의 status code는 error 로 던져집니다! 따라서 이미지 업로드 실패 시 false 를 반환하는 경우는 확인되지 않았습니다. 처리할 때 true인 경우만 생각하시면 될 것 같아요!

## 📷 스크린샷
X

## 🛠️ **Technical Concerns(기술적 고민)**
서버에서 인가를 거쳐 보내주는 Presinged URL에 이미지를 업로드할 때, 헤더, http메소드등 모든 설정이 같고 URL과 이미지 데이터만 변하는데, 이걸 Endpoint로 만들어서 전송하는 것이 조금 비효율적이란 생각이 들었습니다. 그래서 upload함수에 endpoint 대신 String 형의 URL과 Data형의 image만 받는 식으로 변경하는 것은 어떤가에 대해 고민 중입니다. 이에 대해 의견 주시면 감사하겠습니다!

#### 변경 예시
``` swift
  public func upload(presignedURL: String, imageData: Data) -> Single<Bool> {
    let headers: HTTPHeaders = HTTPHeaders([HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.jpeg.rawValue])
    return Single.create { single -> Disposable in
      AF.upload(imageData,
                to: presignedURL,
                method: .put,
                headers: headers)
        .validate(statusCode: 200...299)
```
