### PR TITLE
프로필 수정 UI 구현 및 마이페이지 연결

### DIFF
--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
@@ -46,7 +46,11 @@ public final class MyPageCoordinatorImp: MyPageCoordinator {
       .subscribe(with: self, onNext: { owner, flow in
         switch flow {
         case .showRecordDetail:
-          self.showRecordDetailVC()
+          owner.showRecordDetailVC()
+        case .showProfileEdit:
+          owner.showProfileEditVC()
+        case .showProfileSetting:
+          owner.showProfileSettingVC()
         }
       })
       .disposed(by: disposeBag)
@@ -89,22 +93,25 @@ extension MyPageCoordinatorImp {
 // MARK: - Create and Start(Show) with Flow(View)
 
 extension MyPageCoordinatorImp {
-  
-  /// 새로운 Coordinator를 통해서 새로운 Flow를 생성하기 때문에, start를 prefix로 사용합니다.
-  fileprivate func start__() {
-    /// let __Coordinator = dependencyFactory.make__Coordinator(
-    ///   navigationController: navigationController,
-    ///   parentCoordinator: self
-    /// )
-    /// childCoordinator = __Coordinator
-    /// __Coordinator.start()
-  }
-  
-  /// 단순히, VC를 보여주는 로직이기 때문에, show를 prefix로 사용합니다.
+  /// 기록 상세뷰
   fileprivate func showRecordDetailVC() {
     let reactor = myPageDependencyFactory.makeRecordDetailReactor(coordinator: self)
-     let RecordDetailVC = myPageDependencyFactory.makeRecordDetailViewController(reactor: reactor)
-     self.pushViewController(viewController: RecordDetailVC, animated: false)
+    let RecordDetailVC = myPageDependencyFactory.makeRecordDetailViewController(reactor: reactor)
+    self.pushViewController(viewController: RecordDetailVC, animated: false)
+  }
+  
+  /// 프로필 설정뷰
+  fileprivate func showProfileSettingVC() {
+    let reactor = myPageDependencyFactory.makeProfileSettingReactor(coordinator: self)
+    let ProfileSettingVC = myPageDependencyFactory.makeProfileSettingViewController(reactor: reactor)
+    self.pushViewController(viewController: ProfileSettingVC, animated: false)
+  }
+  
+  /// 프로필 변경뷰
+  fileprivate func showProfileEditVC() {
+    let reactor = myPageDependencyFactory.makeProfileEditReactor(coordinator: self)
+    let ProfileEditVC = myPageDependencyFactory.makeProfileEditViewController(reactor: reactor)
+    self.pushViewController(viewController: ProfileEditVC, animated: false)
   }
 }
 

--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Interface/MyPageCoordinator.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Interface/MyPageCoordinator.swift
@@ -15,6 +15,8 @@ public enum MyPageCoordinatorAction: ParentAction {
 
 public enum MyPageCoordinatorFlow: CoordinatorFlow {
   case showRecordDetail
+  case showProfileEdit
+  case showProfileSetting
 }
 
 public protocol MyPageCoordinator: BaseCoordinator

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
@@ -34,33 +34,34 @@ public class MyPageDependencyFactoryImp: MyPageDependencyFactory {
   }
   
   public func makeMyPageReactor<T: MyPageCoordinator>(coordinator: T) -> any MyPageReactor {
-    return MyPageReactorImp(
-      coordinator: coordinator
-    )
+    return MyPageReactorImp(coordinator: coordinator)
   }
   
   public func makeMyPageViewController<T: MyPageReactor>(reactor: T) -> any MyPageViewController {
     return MyPageViewControllerImp(reactor: reactor)
   }
   
-  public func makeProfileSettingReactor<T: MyPageCoordinator>(coordinator: T) -> any ProfileSettingReactor {
-    return ProfileSettingReactorImp(
-      coordinator: coordinator
-    )
-  }
-  
-  public func makeProfileSettingViewController<T: ProfileSettingReactor>(reactor: T) -> any ProfileSettingViewController {
-    return ProfileSettingViewControllerImp(reactor: reactor)
-  }
-  
   public func makeRecordDetailReactor<T: MyPageCoordinator>(coordinator: T) -> any RecordDetailReactor {
-    return RecordDetailReactorImp(
-      coordinator: coordinator
-    )
+    return RecordDetailReactorImp(coordinator: coordinator)
   }
   
   public func makeRecordDetailViewController<T: RecordDetailReactor>(reactor: T) -> any RecordDetailViewController {
     return RecordDetailViewControllerImp(reactor: reactor)
   }
   
+  public func makeProfileSettingReactor<T: MyPageCoordinator>(coordinator: T) -> any ProfileSettingReactor {
+    return ProfileSettingReactorImp(coordinator: coordinator)
+  }
+  
+  public func makeProfileSettingViewController<T: ProfileSettingReactor>(reactor: T) -> any ProfileSettingViewController {
+    return ProfileSettingViewControllerImp(reactor: reactor)
+  }
+  
+  public func makeProfileEditReactor<T: MyPageCoordinator>(coordinator: T) -> any ProfileEditReactor {
+    return ProfileEditReactorImp(coordinator: coordinator)
+  }
+  
+  public func makeProfileEditViewController<T: ProfileEditReactor>(reactor: T) -> any ProfileEditViewController {
+    return ProfileEditViewControllerImp(reactor: reactor)
+  }
 }

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
@@ -24,4 +24,8 @@ public protocol MyPageDependencyFactory {
   func makeMyPageViewController<T: MyPageReactor>(reactor: T) -> any MyPageViewController
   func makeRecordDetailReactor<T: MyPageCoordinator>(coordinator: T) -> any RecordDetailReactor
   func makeRecordDetailViewController<T: RecordDetailReactor>(reactor: T) -> any RecordDetailViewController
+  func makeProfileEditReactor<T: MyPageCoordinator>(coordinator: T) -> any ProfileEditReactor
+  func makeProfileEditViewController<T: ProfileEditReactor>(reactor: T) -> any ProfileEditViewController
+  func makeProfileSettingReactor<T: MyPageCoordinator>(coordinator: T) -> any ProfileSettingReactor
+  func makeProfileSettingViewController<T: ProfileSettingReactor>(reactor: T) -> any ProfileSettingViewController
 }

--- a/WalWal/DesignSystem/Sources/WalWalInputBox/WalWalInputBox.swift
+++ b/WalWal/DesignSystem/Sources/WalWalInputBox/WalWalInputBox.swift
@@ -106,12 +106,14 @@ public final class WalWalInputBox: UIView {
   public init(
     defaultState: InputBoxActiveState,
     placeholder: String,
-    rightIcon: WlaWalInputBoxIcon = .none
+    rightIcon: WlaWalInputBoxIcon = .none,
+    isAlwaysKeyboard: Bool = false
   ) {
     self.rightButton = WalWalTouchArea(image: rightIcon.image)
     self.rightIcon = rightIcon
     self.stateRelay.accept(defaultState)
     super.init(frame: .zero)
+    self.textField.delegate = isAlwaysKeyboard ? self : nil
     
     configureAttributes(placeholder: placeholder)
     configureLayouts()
@@ -245,6 +247,10 @@ public final class WalWalInputBox: UIView {
   
   // MARK: - Methods
   
+  public func focusOnTextField(){
+    textField.becomeFirstResponder()
+  }
+  
   private func updateAppearance(activeState: InputBoxActiveState) {
     switch activeState {
     case .active:
@@ -254,6 +260,14 @@ public final class WalWalInputBox: UIView {
       textField.textColor = Colors.gray500.color
       isUserInteractionEnabled = false
     }
+  }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension WalWalInputBox: UITextFieldDelegate {
+  public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    return false
   }
 }
 

--- a/WalWal/DesignSystem/Sources/WalWalInputBox/WalWalInputBox.swift
+++ b/WalWal/DesignSystem/Sources/WalWalInputBox/WalWalInputBox.swift
@@ -32,7 +32,7 @@ public final class WalWalInputBox: UIView {
     var image: UIImage? {
       switch self {
       case .close:
-        return Images.closeL.image
+        return Images.closeL.image.withTintColor(Colors.gray500.color)
       case .show:
         return Images.settingL.image.withTintColor(.blue)
       case .none:

--- a/WalWal/DesignSystem/Sources/WalWalNavigationBar/Components/NavigationBarItemType.swift
+++ b/WalWal/DesignSystem/Sources/WalWalNavigationBar/Components/NavigationBarItemType.swift
@@ -19,6 +19,8 @@ public enum NavigationBarItemType {
   case close
   case back
   case setting
+  case darkClose
+  case darkBack
   
   var icon: UIImage? {
     switch self {
@@ -29,7 +31,11 @@ public enum NavigationBarItemType {
     case .back:
       return Images.backL.image
     case .setting:
-      return Images.settingL.image
+      return Images.settingL.image.withTintColor(Colors.black.color, renderingMode: .alwaysOriginal)
+    case .darkClose:
+      return Images.closeL.image.withTintColor(Colors.black.color, renderingMode: .alwaysOriginal)
+    case .darkBack:
+      return Images.backL.image.withTintColor(Colors.black.color, renderingMode: .alwaysOriginal)
     }
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalNavigationBar/WalWalNavigationBar.swift
+++ b/WalWal/DesignSystem/Sources/WalWalNavigationBar/WalWalNavigationBar.swift
@@ -28,7 +28,7 @@ public final class WalWalNavigationBar: UIView {
     let label = UILabel()
     label.textColor = Colors.black.color
     label.textAlignment = .center
-    label.font = Fonts.KR.H4
+    label.font = Fonts.KR.H5.B
     return label
   }()
   

--- a/WalWal/DesignSystem/Sources/WalWalProfile/WalWalProfile.swift
+++ b/WalWal/DesignSystem/Sources/WalWalProfile/WalWalProfile.swift
@@ -67,7 +67,7 @@ public final class WalWalProfile: UIView {
   
   private let rootContainer = UIView()
   lazy var collectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout()).then {
-    $0.backgroundColor = ResourceKitAsset.Colors.white.color
+    $0.backgroundColor = .clear
     $0.register(WalWalProfileCell.self)
     $0.showsHorizontalScrollIndicator = false
     $0.decelerationRate = .fast

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/MyPageReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/MyPageReactorImp.swift
@@ -34,6 +34,8 @@ public final class MyPageReactorImp: MyPageReactor {
       return Observable.just(.setSelectedCalendarItem(model))
     case .didTapSettingButton:
       return Observable.just(.moveToSettingView)
+    case .didTapEditButton:
+      return Observable.just(.moveToEditView)
     }
   }
   
@@ -45,6 +47,8 @@ public final class MyPageReactorImp: MyPageReactor {
       coordinator.destination.accept(.showRecordDetail)
     case .moveToSettingView:
       coordinator.destination.accept(.showProfileSetting)
+    case .moveToEditView:
+      coordinator.destination.accept(.showProfileEdit)
     }
     return newState
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/MyPageReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/MyPageReactorImp.swift
@@ -32,6 +32,8 @@ public final class MyPageReactorImp: MyPageReactor {
     switch action {
     case let .didSelectCalendarItem(model):
       return Observable.just(.setSelectedCalendarItem(model))
+    case .didTapSettingButton:
+      return Observable.just(.moveToSettingView)
     }
   }
   
@@ -41,6 +43,8 @@ public final class MyPageReactorImp: MyPageReactor {
     case let .setSelectedCalendarItem(date):
       newState.selectedDate = date
       coordinator.destination.accept(.showRecordDetail)
+    case .moveToSettingView:
+      coordinator.destination.accept(.showProfileSetting)
     }
     return newState
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
@@ -30,9 +30,34 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
     self.coordinator = coordinator
   }
   
+  // TODO: 유효성 체크로 변경 필요
+  
   public func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case let .checkCondition(nickname):
+      return .just(.showIndicator(show: true))
+    case let .editProfile(nickname, profileURL):
+      return .concat([
+        .just(.showIndicator(show: true)),
+      ])
+    }
   }
   
   public func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+    switch mutation {
+    case let .buttonEnable(isEnable):
+      newState.buttonEnable = isEnable
+    case let .invaildNickname(message):
+      newState.invaildMessage = message
+    case let .showIndicator(show):
+      newState.showIndicator = show
+    }
+    return newState
+  }
+  
+  
+  private func checkNickname(nickname: String) {
+    
   }
 }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
@@ -1,0 +1,38 @@
+//
+//  ProfileEditReactorImp.swift
+//  MyPagePresenter
+//
+//  Created by 이지희 on 8/14/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import MyPageDomain
+import MyPagePresenter
+import MyPageCoordinator
+
+import ReactorKit
+import RxSwift
+
+public final class ProfileEditReactorImp: ProfileEditReactor {
+  
+  public typealias Action = ProfileEditReactorAction
+  public typealias Mutation = ProfileEditReactorMutation
+  public typealias State = ProfileEditReactorState
+  
+  public let initialState: State
+  public let coordinator: any MyPageCoordinator
+  
+  public init(
+    coordinator: any MyPageCoordinator
+  ) {
+    
+    self.initialState = State()
+    self.coordinator = coordinator
+  }
+  
+  public func mutate(action: Action) -> Observable<Mutation> {
+  }
+  
+  public func reduce(state: State, mutation: Mutation) -> State {
+  }
+}

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
@@ -50,6 +50,8 @@ public final class ProfileSettingReactorImp: ProfileSettingReactor {
       ])
     case let .didSelectItem(at: indexPath):
       return handleSelection(at: indexPath)
+    case .tapBackButton:
+      return Observable.just(.moveToBack)
     }
   }
   
@@ -73,6 +75,8 @@ public final class ProfileSettingReactorImp: ProfileSettingReactor {
       newState.isRevokeSuccess = success
     case let .setIsRecentVersion(isRecent):
       newState.isRecent = isRecent
+    case .moveToBack:
+      coordinator.popViewController(animated: true)
     }
     return newState
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
@@ -34,7 +34,8 @@ public final class MyPageViewControllerImp<R: MyPageReactor>: UIViewController, 
   private let navigationBar = WalWalNavigationBar(
     leftItems: [],
     title: "내 정보",
-    rightItems: [.setting]
+    rightItems: [.setting],
+    rightItemSize: 40
   ).then { $0.backgroundColor = Colors.white.color }
   
   private let seperator = UIView().then {
@@ -48,9 +49,7 @@ public final class MyPageViewControllerImp<R: MyPageReactor>: UIViewController, 
     name: "조용인",
     subDescription: "안녕하세요 반가워요 👍🏻",
     chipStyle: .tonal,
-    chipTitle: "눌러봐",
-    selectedChipStyle: .filled,
-    selectedChipTitle: "🔥"
+    chipTitle: "수정"
   )
   
   public var disposeBag = DisposeBag()
@@ -128,14 +127,19 @@ extension MyPageViewControllerImp: View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
-    navigationBar.rightItems?[0].rx
-      .tapped
+    navigationBar.rightItems?[0].rx.tapped
       .map {
         Reactor.Action.didTapSettingButton
       }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
+    profileCardView.rx.chipTapped
+      .map {
+        Reactor.Action.didTapEditButton
+      }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
   }
   
   public func bindState(reactor: R) {

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
@@ -127,6 +127,15 @@ extension MyPageViewControllerImp: View {
       }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+    
+    navigationBar.rightItems?[0].rx
+      .tapped
+      .map {
+        Reactor.Action.didTapSettingButton
+      }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
   }
   
   public func bindState(reactor: R) {

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -23,13 +23,13 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
   
   private typealias FontKR = ResourceKitFontFamily.KR
   private typealias FontEN = ResourceKitFontFamily.EN
-  private typealias AssetColor = ResourceKitAsset.Colors
-  private typealias AssetImage = ResourceKitAsset.Assets
+  private typealias Colors = ResourceKitAsset.Colors
+  private typealias Images = ResourceKitAsset.Assets
   
   // MARK: - UI
   
   private let containerView = UIView().then {
-    $0.backgroundColor = AssetColor.gray150.color
+    $0.backgroundColor = Colors.gray150.color
   }
   private let navigationBarView = WalWalNavigationBar(
     leftItems: [],
@@ -37,7 +37,7 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
     rightItems: [.darkClose],
     rightItemSize: 40
   ).then {
-    $0.backgroundColor = AssetColor.white.color
+    $0.backgroundColor = Colors.white.color
   }
   private let profileEditView = WalWalProfile(type: .dog)
   private let nicknameTextfield = WalWalInputBox(
@@ -74,7 +74,7 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
   }
   
   public override func viewDidLayoutSubviews() {
-    view.backgroundColor = AssetColor.white.color
+    view.backgroundColor = Colors.white.color
     super.viewDidLayoutSubviews()
     containerView.pin
       .all(view.pin.safeArea)
@@ -84,7 +84,7 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
   
   
   public func configureAttribute() {
-    view.backgroundColor = AssetColor.white.color
+    view.backgroundColor = Colors.white.color
   }
   
   public func configureLayout() {

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -65,12 +65,16 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
   
   // MARK: - Lifecycle
   
+  public override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    nicknameTextfield.focusOnTextField()
+  }
+  
   public override func viewDidLoad() {
     self.reactor = profileEditReactor
     super.viewDidLoad()
     configureAttribute()
     configureLayout()
-    nicknameTextfield.becomeFirstResponder()
   }
   
   public override func viewDidLayoutSubviews() {

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -122,6 +122,17 @@ extension ProfileEditViewControllerImp: View {
   public func bindState(reactor: R) {  }
   
   public func bindEvent() {
+    navigationBarView.rightItems?.first?.rx.tapped
+      .asDriver()
+      .drive(with: self) { owner, _ in
+        owner.navigationController?.popViewController(animated: true)
+      }
+      .disposed(by: disposeBag)
     
+    profileEditView.showPHPicker
+      .bind(with: self) { owner, _ in
+        PHPickerManager.shared.presentPicker(vc: owner)
+      }
+      .disposed(by: disposeBag)
   }
 }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -1,0 +1,127 @@
+//
+//  ProfileEditViewImp.swift
+//  MyPagePresenter
+//
+//  Created by 이지희 on 8/14/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import UIKit
+import MyPagePresenter
+import DesignSystem
+import ResourceKit
+import Utility
+
+import Then
+import PinLayout
+import FlexLayout
+import ReactorKit
+import RxSwift
+import RxCocoa
+
+public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewController, ProfileEditViewController {
+  
+  private typealias FontKR = ResourceKitFontFamily.KR
+  private typealias FontEN = ResourceKitFontFamily.EN
+  private typealias AssetColor = ResourceKitAsset.Colors
+  private typealias AssetImage = ResourceKitAsset.Assets
+  
+  // MARK: - UI
+  
+  private let containerView = UIView().then {
+    $0.backgroundColor = AssetColor.gray150.color
+  }
+  private let navigationBarView = WalWalNavigationBar(
+    leftItems: [],
+    title: "프로필 수정",
+    rightItems: [.darkClose],
+    rightItemSize: 40
+  ).then {
+    $0.backgroundColor = AssetColor.white.color
+  }
+  private let profileEditView = WalWalProfile(type: .dog)
+  private let nicknameTextfield = WalWalInputBox(
+    defaultState: .active,
+    placeholder: "",
+    rightIcon: .close
+  )
+  private let completeButton = WalWalButton(type: .active, title: "완료")
+  
+  public var disposeBag = DisposeBag()
+  public var profileEditReactor: R
+  
+  // MARK: - Initializer
+  
+  public init(
+    reactor: R
+  ) {
+    self.profileEditReactor = reactor
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Lifecycle
+  
+  public override func viewDidLoad() {
+    self.reactor = profileEditReactor
+    super.viewDidLoad()
+    configureAttribute()
+    configureLayout()
+    nicknameTextfield.becomeFirstResponder()
+  }
+  
+  public override func viewDidLayoutSubviews() {
+    view.backgroundColor = AssetColor.white.color
+    super.viewDidLayoutSubviews()
+    containerView.pin
+      .all(view.pin.safeArea)
+    containerView.flex
+      .layout()
+  }
+  
+  
+  public func configureAttribute() {
+    view.backgroundColor = AssetColor.white.color
+  }
+  
+  public func configureLayout() {
+    view.addSubview(containerView)
+    
+    containerView.flex
+      .direction(.column)
+      .define {
+        $0.addItem(navigationBarView)
+        $0.addItem(profileEditView)
+          .marginTop(55.adjusted)
+          .marginHorizontal(0)
+        $0.addItem(nicknameTextfield)
+          .marginTop(40.adjusted)
+          .marginHorizontal(20.adjusted)
+          .marginBottom(5.adjusted)
+        $0.addItem(completeButton)
+          .marginHorizontal(20.adjusted)
+      }
+  }
+}
+
+extension ProfileEditViewControllerImp: View {
+  
+  // MARK: - Binding
+  
+  public func bind(reactor: R) {
+    bindAction(reactor: reactor)
+    bindState(reactor: reactor)
+    bindEvent()
+  }
+  
+  public func bindAction(reactor: R) {  }
+  
+  public func bindState(reactor: R) {  }
+  
+  public func bindEvent() {
+    
+  }
+}

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -43,7 +43,8 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
   private let nicknameTextfield = WalWalInputBox(
     defaultState: .active,
     placeholder: "",
-    rightIcon: .close
+    rightIcon: .close,
+    isAlwaysKeyboard: true
   )
   private let completeButton = WalWalButton(type: .active, title: "완료")
   
@@ -121,7 +122,14 @@ extension ProfileEditViewControllerImp: View {
     bindEvent()
   }
   
-  public func bindAction(reactor: R) {  }
+  public func bindAction(reactor: R) {
+    let nicknameObservable = nicknameTextfield.rx.text.orEmpty
+      .throttle(.milliseconds(350), scheduler: MainScheduler.instance)
+    
+    let input = Observable.combineLatest(nicknameObservable, profileEditView.curProfileItems)
+    
+    
+  }
   
   public func bindState(reactor: R) {  }
   

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
@@ -43,14 +43,14 @@ public final class ProfileSettingViewControllerImp<R: ProfileSettingReactor>: UI
   }
   
   public var disposeBag = DisposeBag()
-  public var __reactor: R
+  public var profileSetting: R
   
   // MARK: - Initializer
   
   public init(
     reactor: R
   ) {
-    self.__reactor = reactor
+    self.profileSetting = reactor
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -61,7 +61,7 @@ public final class ProfileSettingViewControllerImp<R: ProfileSettingReactor>: UI
   // MARK: - Lifecycle
   
   public override func viewDidLoad() {
-    self.reactor = __reactor
+    self.reactor = profileSetting
     super.viewDidLoad()
     setAttribute()
     setLayout()

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
@@ -30,7 +30,7 @@ public final class ProfileSettingViewControllerImp<R: ProfileSettingReactor>: UI
   
   private let containerView = UIView()
   private let navigationBar = WalWalNavigationBar(
-    leftItems: [.back],
+    leftItems: [.darkBack],
     title: "설정",
     rightItems: []
   )
@@ -113,6 +113,11 @@ extension ProfileSettingViewControllerImp: View {
     settingTableView.rx
       .itemSelected
       .map { Reactor.Action.didSelectItem(at: $0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    navigationBar.leftItems?[0].rx.tapped
+      .map { Reactor.Action.tapBackButton }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/MyPageReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/MyPageReactor.swift
@@ -16,11 +16,13 @@ import RxSwift
 public enum MyPageReactorAction {
   case didSelectCalendarItem(WalWalCalendarModel)
   case didTapSettingButton
+  case didTapEditButton
 }
 
 public enum MyPageReactorMutation {
   case setSelectedCalendarItem(WalWalCalendarModel)
   case moveToSettingView
+  case moveToEditView
 }
 
 public struct MyPageReactorState {

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/MyPageReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/MyPageReactor.swift
@@ -15,10 +15,12 @@ import RxSwift
 
 public enum MyPageReactorAction {
   case didSelectCalendarItem(WalWalCalendarModel)
+  case didTapSettingButton
 }
 
 public enum MyPageReactorMutation {
   case setSelectedCalendarItem(WalWalCalendarModel)
+  case moveToSettingView
 }
 
 public struct MyPageReactorState {

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
@@ -1,0 +1,37 @@
+//
+//  ProfileEditReactor.swift
+//  MyPagePresenter
+//
+//  Created by 이지희 on 8/14/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import MyPageDomain
+import MyPageCoordinator
+
+import ReactorKit
+import RxSwift
+
+public enum ProfileEditReactorAction {
+}
+
+public enum ProfileEditReactorMutation {
+}
+
+public struct ProfileEditReactorState {
+  public init() {
+  
+  }
+}
+
+
+public protocol ProfileEditReactor: Reactor where Action == ProfileEditReactorAction,
+                                                   Mutation == ProfileEditReactorMutation,
+                                                   State == ProfileEditReactorState {
+  
+  var coordinator: any MyPageCoordinator { get }
+  
+  init(
+    coordinator: any MyPageCoordinator
+  )
+}

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
@@ -13,15 +13,21 @@ import ReactorKit
 import RxSwift
 
 public enum ProfileEditReactorAction {
+  case editProfile(nickname: String, profileURL: String)
+  case checkCondition(nickname: String)
 }
 
 public enum ProfileEditReactorMutation {
+  case invaildNickname(message: String)
+  case buttonEnable(isEnable: Bool)
+  case showIndicator(show: Bool)
 }
 
 public struct ProfileEditReactorState {
-  public init() {
-  
-  }
+  public init() { }
+  public var buttonEnable: Bool = false
+  public var showIndicator: Bool = false
+  @Pulse public var invaildMessage: String = ""
 }
 
 

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileSettingReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileSettingReactor.swift
@@ -37,6 +37,7 @@ public enum ProfileSettingReactorAction {
   
   case viewDidLoad
   case didSelectItem(at: IndexPath)
+  case tapBackButton
 }
 
 public enum ProfileSettingReactorMutation {
@@ -46,6 +47,7 @@ public enum ProfileSettingReactorMutation {
   case setSettingItemModel([ProfileSettingItemModel])
   case setLogout(Bool)
   case setRevoke(Bool)
+  case moveToBack
 }
 
 public struct ProfileSettingReactorState {

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Views/ProfileEditView.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Views/ProfileEditView.swift
@@ -1,0 +1,24 @@
+//
+//  ProfileEditView.swift
+//  MyPagePresenter
+//
+//  Created by 이지희 on 8/14/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import UIKit
+
+import ReactorKit
+import RxSwift
+
+public protocol ProfileEditViewController: UIViewController {
+  
+  associatedtype ProfileEditReactorType: ProfileEditReactor
+  var disposeBag: DisposeBag { get set }
+  
+  func configureLayout()
+  func configureAttribute()
+  func bindAction(reactor: ProfileEditReactorType)
+  func bindState(reactor: ProfileEditReactorType)
+  func bindEvent()
+}

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Views/ProfileSettingView.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Views/ProfileSettingView.swift
@@ -11,7 +11,7 @@ import UIKit
 import ReactorKit
 import RxSwift
 
-public protocol ProfileSettingViewController {
+public protocol ProfileSettingViewController: UIViewController {
   
   associatedtype ProfileSettingReactorType: ProfileSettingReactor
   var disposeBag: DisposeBag { get set }


### PR DESCRIPTION
## 📌 개요
프로필 수정 및 마이페이지 flow 연결했습니다. 

## ✍️ 변경사항
_디자인 시스템에 일부 코드 변경 있어서 확인해주시면 감사하겠습니다 !_
#### WalWalInputBox
1. return 시 키보드 내려가지 않도록 `isAlwaysKeyboard` Bool 값으로 조정
https://github.com/depromeet/WalWal-iOS/blob/75fc1a18c641e78be196bb2643938067b3bc29ff/WalWal/DesignSystem/Sources/WalWalInputBox/WalWalInputBox.swift#L106-L116
- Bool값에 따라 delegate 설정을 할당, 해제 하는 방식으로 조정했습니다. 

2. 뷰 진입 시 바로 inputBox 포커싱되는 함수 추가
https://github.com/depromeet/WalWal-iOS/blob/75fc1a18c641e78be196bb2643938067b3bc29ff/WalWal/DesignSystem/Sources/WalWalInputBox/WalWalInputBox.swift#L250-L252
- `public` 으로 선언하여 뷰 진입 시에 호출 될 수 있도록 구현했습니다. 


## 📷 스크린샷
| 플로우 | SE 기기대응 테스트 |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/509b00b5-067a-42a0-a598-e9cf8515404a" width="375"> | <img src="https://github.com/user-attachments/assets/3d16044f-1e50-4d32-ba08-261ed6457dfb" width="375"> |



## 🛠️ **Technical Concerns(기술적 고민)**
프로필 정보 유효성 검사, 닉네임 중복 검사 등의 함수가 공통적으로 사용될 것 같은데, 온보딩의 함수를 같이 쓸 수 있는 방법을 생각해봐야 할 것 같습니다 ! 공통적으로 사용할 수 있는 모듈로 로직 옮기는 거 어떻게 생각하시나요..?! 공수가 많이 든다면 UseCase만 공유해도 될 것 같아요 @ji-yeon224 
