### PR TITLE
네트워크 요청 시 에러 핸들링 수정

### DIFF
--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Reactors/OnboardingProfileReactorImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Reactors/OnboardingProfileReactorImp.swift
@@ -99,7 +99,7 @@ extension OnboardingProfileReactorImp {
         return .concat([
           .just(.showIndicator(show: false)),
           .just(.buttonEnable(isEnable: false)),
-          .just(.invalidNickname(message: OnboardingError.duplicateNickname.message))
+          .just(.invalidNickname(message: error.localizedDescription))
         ])
       }
       
@@ -117,7 +117,7 @@ extension OnboardingProfileReactorImp {
       .catch { error -> Observable<Mutation> in
         return .concat([
           .just(.showIndicator(show: false)),
-          .just(.registerError(message: OnboardingError.imageUploadError.message))
+          .just(.invalidNickname(message: error.localizedDescription))
         ])
       }
   }
@@ -149,6 +149,7 @@ extension OnboardingProfileReactorImp {
       }
       .catch { _ -> Observable<Mutation> in
         print("FCM 토큰 저장 오류")
+        self.coordinator.startMission()
         return .concat([
           .just(.showIndicator(show: false)),
           .just(.registerError(message: OnboardingError.registerError.message))

--- a/WalWal/WalWalNetwork/Sources/Foundation/ErrorResponse.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/ErrorResponse.swift
@@ -1,0 +1,14 @@
+//
+//  ErrorResponse.swift
+//  WalWalNetwork
+//
+//  Created by Jiyeon on 8/19/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import Foundation
+
+struct ErrorResponse: Decodable {
+  public var errorClassName: String
+  public var message: String
+}

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkError.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkError.swift
@@ -13,8 +13,8 @@ import Foundation
 /// NetworkError: 네트워크 요청 중 발생할 수 있는 에러 타입을 정의
 public enum WalWalNetworkError: Error {
   case invalidRequest
-  case networkError(Int)
-  case serverError(statusCode: Int)
+  case networkError(message: String?)
+  case serverError(message: String?)
   case decodingError(Error)
   case tokenReissueFailed
   case retryExceeded(Error)
@@ -28,10 +28,12 @@ extension WalWalNetworkError: LocalizedError {
       return "해당 요청이 유효하지 않습니다."
     case .decodingError:
       return "데이터 타입을 decode 하는데에 실패하였습니다."
-    case .serverError(let code):
-      return "서버 에러가 발생했습니다. \(code)"
-    case .networkError(let code):
-      return "네트워크 오류입니다 \(code)"
+    case .serverError(let message):
+      let message = message ?? "서버에 문제가 발생하였습니다."
+      return "\(message)"
+    case .networkError(let message):
+      let message = message ?? "요청에 문제가 발생하였습니다."
+      return "\(message)"
     case .tokenReissueFailed:
       return "토큰 재발급에 실패했습니다. 다시 로그인해주세요."
     case .retryExceeded(let error):

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
@@ -33,12 +33,12 @@ public final class NetworkService: NetworkServiceProtocol {
         print(error.localizedDescription)
         guard let afError = error.asAFError, let responseCode = afError.responseCode else {
           let walwalError = WalWalNetworkError.unknown(error)
-          self.responseError(endpoint, result: walwalError)
+          self.responseError(endpoint, statusCode: -1, result: walwalError)
           return .error(walwalError)
         }
         
-        let walwalError = WalWalNetworkError.networkError(responseCode)
-        self.responseError(endpoint, result: walwalError)
+        let walwalError = WalWalNetworkError.networkError(statusCode: responseCode, message: "")
+        self.responseError(endpoint, statusCode: responseCode, result: walwalError)
         return .error(walwalError)
       })
       .withUnretained(self)
@@ -78,7 +78,7 @@ public final class NetworkService: NetworkServiceProtocol {
           case .success(_):
             single(.success(true))
           case .failure(let fail):
-            let error = WalWalNetworkError.networkError(fail.responseCode ?? 0)
+            let error = WalWalNetworkError.networkError(statusCode: fail.responseCode ?? 0, message: "")
             single(.failure(error))
           }
         }
@@ -98,16 +98,20 @@ extension NetworkService {
   ) -> Result<T?, Error> {
     let statusCode = response.statusCode
     if !(200...299).contains(statusCode) {
-      var error = WalWalNetworkError.serverError(statusCode: statusCode)
-      switch statusCode {
-      case 400...499:
-        error = WalWalNetworkError.networkError(statusCode)
-      case 500...599:
-        error = WalWalNetworkError.serverError(statusCode: statusCode)
-      default:
-        error = WalWalNetworkError.networkError(statusCode)
-      }
-      responseError(endpoint, result: error)
+      var error = WalWalNetworkError.serverError(statusCode: statusCode, message: nil)
+      do {
+        let errorResponse = try JSONDecoder().decode(BaseResponse<ErrorResponse>.self, from: data)
+        switch statusCode {
+        case 400...499:
+          error = WalWalNetworkError.networkError(statusCode: statusCode, message: errorResponse.data?.message)
+        case 500...599:
+          error = WalWalNetworkError.serverError(statusCode: statusCode, message: errorResponse.data?.message)
+        default:
+          error = WalWalNetworkError.networkError(statusCode: statusCode, message: nil)
+        }
+      } catch { }
+     
+      responseError(endpoint, statusCode: statusCode, result: error)
       return .failure(error)
     }
     do {
@@ -116,13 +120,13 @@ extension NetworkService {
         responseSuccess(endpoint, result: responseModel)
         return .success(responseModel.data)
       } else {
-        let error = WalWalNetworkError.networkError(statusCode)
-        responseError(endpoint, result: error)
+        let error = WalWalNetworkError.networkError(statusCode: statusCode, message: "")
+        responseError(endpoint, statusCode: statusCode, result: error)
         return .failure(error)
       }
     } catch {
       let decodingError = WalWalNetworkError.decodingError(error)
-      responseError(endpoint, result: decodingError)
+      responseError(endpoint, statusCode: statusCode, result: decodingError)
       return .failure(decodingError)
     }
   }
@@ -149,12 +153,13 @@ extension NetworkService {
           """)
   }
   
-  private func responseError(_ endpoint: any APIEndpoint, result error: WalWalNetworkError) {
+  private func responseError(_ endpoint: any APIEndpoint, statusCode: Int , result error: WalWalNetworkError) {
     print("""
               ======================== 📥 Response <========================
               ========================= ❌ Error.. =========================
               ❗️ URL: \(endpoint.baseURL.absoluteString + endpoint.path)
               ❗️ Header: \(endpoint.headers)
+              ❗️ StatusCode: \(statusCode)
               ❗️ Error_Data: \(error.errorDescription ?? "Unknown Error Occured")
               ==============================================================
           """)

--- a/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
+++ b/WalWal/WalWalNetwork/Sources/Foundation/NetworkServiceImp.swift
@@ -37,7 +37,7 @@ public final class NetworkService: NetworkServiceProtocol {
           return .error(walwalError)
         }
         
-        let walwalError = WalWalNetworkError.networkError(statusCode: responseCode, message: "")
+        let walwalError = WalWalNetworkError.networkError(message: nil)
         self.responseError(endpoint, statusCode: responseCode, result: walwalError)
         return .error(walwalError)
       })
@@ -78,7 +78,7 @@ public final class NetworkService: NetworkServiceProtocol {
           case .success(_):
             single(.success(true))
           case .failure(let fail):
-            let error = WalWalNetworkError.networkError(statusCode: fail.responseCode ?? 0, message: "")
+            let error = WalWalNetworkError.networkError(message: nil)
             single(.failure(error))
           }
         }
@@ -98,16 +98,16 @@ extension NetworkService {
   ) -> Result<T?, Error> {
     let statusCode = response.statusCode
     if !(200...299).contains(statusCode) {
-      var error = WalWalNetworkError.serverError(statusCode: statusCode, message: nil)
+      var error = WalWalNetworkError.serverError(message: nil)
       do {
         let errorResponse = try JSONDecoder().decode(BaseResponse<ErrorResponse>.self, from: data)
         switch statusCode {
         case 400...499:
-          error = WalWalNetworkError.networkError(statusCode: statusCode, message: errorResponse.data?.message)
+          error = WalWalNetworkError.networkError(message: errorResponse.data?.message)
         case 500...599:
-          error = WalWalNetworkError.serverError(statusCode: statusCode, message: errorResponse.data?.message)
+          error = WalWalNetworkError.serverError(message: errorResponse.data?.message)
         default:
-          error = WalWalNetworkError.networkError(statusCode: statusCode, message: nil)
+          error = WalWalNetworkError.networkError(message: nil)
         }
       } catch { }
      
@@ -120,7 +120,7 @@ extension NetworkService {
         responseSuccess(endpoint, result: responseModel)
         return .success(responseModel.data)
       } else {
-        let error = WalWalNetworkError.networkError(statusCode: statusCode, message: "")
+        let error = WalWalNetworkError.networkError(message: nil)
         responseError(endpoint, statusCode: statusCode, result: error)
         return .failure(error)
       }


### PR DESCRIPTION
## 📌 개요
에러 핸들링 수정

## ✍️ 변경사항
기존 에러 핸들링은 status code로만 식별이 가능해서 정확한 오류 메세지 파악이 어려웠습니다. 
Error 발생 시 response data를 디코딩하였고, 서버에서 보내준 에러 메세지 localizedDescription으로 수정하였습니다.

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/21b7cb3f-010a-4873-a48f-fa8a93688d37)

## 🛠️ **Technical Concerns(기술적 고민)**
더 좋은 방법이 있다면 알려주십셔!
