### PR TITLE
MissionView 권한 검사 로직 추가

### DIFF
--- a/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
@@ -11,6 +11,7 @@ import MissionPresenter
 import MissionCoordinator
 import MissionDomain
 import RecordsDomain
+import Utility
 
 import ReactorKit
 import RxSwift
@@ -28,6 +29,8 @@ public final class MissionReactorImp: MissionReactor {
   public let checkCompletedTotalRecordsUseCase: CheckCompletedTotalRecordsUseCase
   public let checkRecordStatusUseCase: CheckRecordStatusUseCase
   public let startRecordUseCase: StartRecordUseCase
+  
+  private let disposeBag = DisposeBag()
   
   public init(
     coordinator: any MissionCoordinator,
@@ -52,7 +55,11 @@ public final class MissionReactorImp: MissionReactor {
         fetchMissionDataAndCount(),
         Observable.just(Mutation.setLoading(false))
       ])
+    case .checkPermission:
+      return checkNotificationPermission()
+        .map { Mutation.setNotiPermission($0) }
     case let .startMission(id):
+      startMission()
       return startMission(id: id)
     case .startTimer:
       return startMissionTimer()
@@ -85,6 +92,10 @@ public final class MissionReactorImp: MissionReactor {
       newState.isLoading = false
     case .setButtionText(let text):
       newState.buttonText = text
+    case .setNotiPermission(let isAllow):
+      newState.isAllowNoti = isAllow
+    case .setCamPermission(let isAllow):
+      newState.isAllowCamera = isAllow
     }
     return newState
   }
@@ -188,4 +199,36 @@ public final class MissionReactorImp: MissionReactor {
       .disposed(by: timerDisposeBag)
   }
   
+  
+  /// 알림 권한 확인
+  private func checkNotificationPermission() -> Observable<Bool> {
+    return PermissionManager.shared.checkPermission(for: .notification)
+      .flatMap { isGranted in
+        if !isGranted {
+          return PermissionManager.shared.requestNotificationPermission()
+        }
+        return Observable.just(isGranted)
+      }
+  }
+  
+  /// 미션 시작 전 카메라 권한 확인
+  private func startMission() {
+    PermissionManager.shared.checkPermission(for: .camera)
+      .subscribe(with: self, onNext: { owner, isGranted in
+        if isGranted {
+          // 미션 시작
+        } else {
+          PermissionManager.shared.requestCameraPermission()
+            .subscribe(with: self, onNext: { owner, granted in
+              if granted {
+                // 미션 시작
+              } else {
+                // 권한 없음 -> 토스트 메시지로 권한 요청?
+              }
+            })
+            .disposed(by: owner.disposeBag)
+        }
+      })
+      .disposed(by: disposeBag)
+  }
 }

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
@@ -47,6 +47,13 @@ public final class MissionReactorImp: MissionReactor {
     self.initialState = State()
   }
   
+  public func transform(action: Observable<Action>) -> Observable<Action> {
+    let initialLoadAction = Observable.just(Action.loadMission)
+    let initialPermissionCheck = Observable.just(Action.checkPermission)
+    
+    return Observable.merge(action, initialLoadAction, initialPermissionCheck)
+  }
+  
   public func mutate(action: Action) -> Observable<Mutation> {
     switch action {
     case .loadMissionInfo:

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
@@ -48,7 +48,7 @@ public final class MissionReactorImp: MissionReactor {
   }
   
   public func transform(action: Observable<Action>) -> Observable<Action> {
-    let initialLoadAction = Observable.just(Action.loadMission)
+    let initialLoadAction = Observable.just(Action.loadMissionInfo)
     let initialPermissionCheck = Observable.just(Action.checkPermission)
     
     return Observable.merge(action, initialLoadAction, initialPermissionCheck)

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
@@ -66,6 +66,11 @@ public final class BubbleView: UIView {
   
   // MARK: - Method
   
+  override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    return false 
+  }
+  
+  
   private func configureAttribute() {
     self.addSubview(containerView)
     containerView.pin

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -137,7 +137,10 @@ extension MissionViewControllerImp: View {
   
   public func bindAction(reactor: R) {
     reactor.action
-      .onNext(.loadMissionInfo)
+      .onNext(.loadMission)
+    
+    reactor.action
+      .onNext(.checkPermission)
   }
   
   public func bindState(reactor: R) {

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -136,11 +136,12 @@ extension MissionViewControllerImp: View {
   }
   
   public func bindAction(reactor: R) {
-    reactor.action
-      .onNext(.loadMission)
-    
-    reactor.action
-      .onNext(.checkPermission)
+    missionStartButton.rx.tapped
+      .bind(with: self) { owner, _ in
+        owner.reactor?.action
+          .onNext(.startMission)
+      }
+      .disposed(by: disposeBag)
   }
   
   public func bindState(reactor: R) {

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -136,10 +136,12 @@ extension MissionViewControllerImp: View {
   }
   
   public func bindAction(reactor: R) {
-    missionStartButton.rx.tapped
-      .map{ Reactor.Action.startMission }
-      .bind(to: reactor.action)
-      .disposed(by: disposeBag)
+      missionStartButton.rx.tapped
+        .map { [weak self] in
+          return Reactor.Action.startMission(self?.missionId ?? 0)
+        }
+        .bind(to: reactor.action)
+        .disposed(by: disposeBag)
   }
   
   public func bindState(reactor: R) {
@@ -184,18 +186,9 @@ extension MissionViewControllerImp: View {
         }
       }
       .disposed(by: disposeBag)
-    
-    
-    
   }
   
   public func bindEvent() {
-    missionStartButton.rx.tapped
-      .subscribe(with: self) { owner, _ in
-        owner.reactor?.action
-          .onNext(.startMission(owner.missionId))
-        print("미션 시작")
-      }
-      .disposed(by: disposeBag)
+
   }
 }

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -137,10 +137,8 @@ extension MissionViewControllerImp: View {
   
   public func bindAction(reactor: R) {
     missionStartButton.rx.tapped
-      .bind(with: self) { owner, _ in
-        owner.reactor?.action
-          .onNext(.startMission)
-      }
+      .map{ Reactor.Action.startMission }
+      .bind(to: reactor.action)
       .disposed(by: disposeBag)
   }
   

--- a/WalWal/Features/Mission/MissionPresenter/Interface/Reactors/MissionReactor.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Interface/Reactors/MissionReactor.swift
@@ -18,6 +18,7 @@ public enum MissionReactorAction {
   case loadMissionInfo
   case startMission(Int)
   case startTimer
+  case checkPermission
 }
 
 public enum MissionReactorMutation {
@@ -28,6 +29,8 @@ public enum MissionReactorMutation {
   case setMissionStatus(MissionRecordStatusModel)
   case setMissionCount(Int)
   case setButtionText(String)
+  case setNotiPermission(Bool)
+  case setCamPermission(Bool)
 }
 
 
@@ -38,6 +41,8 @@ public struct MissionReactorState {
   public var missionStatus: MissionRecordStatusModel?
   public var totalMissionCount : Int = 0
   public var buttonText: String = "미션 시작하기" // 초기값
+  public var isAllowNoti: Bool = false
+  public var isAllowCamera: Bool = false
   
   public init() {
     

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
@@ -9,6 +9,7 @@
 import MyPageDomain
 import MyPagePresenter
 import MyPageCoordinator
+import Utility
 
 import ReactorKit
 import RxSwift
@@ -40,6 +41,9 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
       return .concat([
         .just(.showIndicator(show: true)),
       ])
+    case .checkPhotoPermission:
+      return checkPhotoPermission()
+        .map{ Mutation.setPhotoPermission(isAllow: $0) }
     }
   }
   
@@ -52,6 +56,8 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
       newState.invaildMessage = message
     case let .showIndicator(show):
       newState.showIndicator = show
+    case let .setPhotoPermission(isAllow: isAllow):
+      newState.isGrantedPhoto = isAllow
     }
     return newState
   }
@@ -59,5 +65,15 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
   
   private func checkNickname(nickname: String) {
     
+  }
+  
+  private func checkPhotoPermission() -> Observable<Bool> {
+    return PermissionManager.shared.checkPermission(for: .photo)
+      .flatMap { isGranted in
+        if !isGranted {
+          return PermissionManager.shared.requestPhotoPermission()
+        }
+        return Observable.just(isGranted)
+      }
   }
 }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
@@ -43,7 +43,7 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
       ])
     case .checkPhotoPermission:
       return checkPhotoPermission()
-        .map{ Mutation.setPhotoPermission(isAllow: $0) }
+        .map{ Mutation.setPhotoPermission($0) }
     case .tapCancelButton:
       return .just(.moveToBack)
     }
@@ -58,7 +58,7 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
       newState.invaildMessage = message
     case let .showIndicator(show):
       newState.showIndicator = show
-    case let .setPhotoPermission(isAllow: isAllow):
+    case let .setPhotoPermission(isAllow):
       newState.isGrantedPhoto = isAllow
     case .moveToBack:
       coordinator.popViewController(animated: true)

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
@@ -44,6 +44,8 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
     case .checkPhotoPermission:
       return checkPhotoPermission()
         .map{ Mutation.setPhotoPermission(isAllow: $0) }
+    case .tapCancelButton:
+      return .just(.moveToBack)
     }
   }
   
@@ -58,6 +60,8 @@ public final class ProfileEditReactorImp: ProfileEditReactor {
       newState.showIndicator = show
     case let .setPhotoPermission(isAllow: isAllow):
       newState.isGrantedPhoto = isAllow
+    case .moveToBack:
+      coordinator.popViewController(animated: true)
     }
     return newState
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -133,6 +133,10 @@ extension ProfileEditViewControllerImp: View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
+    navigationBarView.rightItems?.first?.rx.tapped
+      .map { Reactor.Action.tapCancelButton }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
   }
   
   public func bindState(reactor: R) {
@@ -150,11 +154,6 @@ extension ProfileEditViewControllerImp: View {
   }
   
   public func bindEvent() {
-    navigationBarView.rightItems?.first?.rx.tapped
-      .asDriver()
-      .drive(with: self) { owner, _ in
-        owner.navigationController?.popViewController(animated: true)
-      }
-      .disposed(by: disposeBag)
+
   }
 }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -143,6 +143,8 @@ extension ProfileEditViewControllerImp: View {
     
     profileEditView.showPHPicker
       .bind(with: self) { owner, _ in
+        owner.reactor?.action
+          .onNext(.checkPhotoPermission)
         PHPickerManager.shared.presentPicker(vc: owner)
       }
       .disposed(by: disposeBag)

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
@@ -23,7 +23,7 @@ public enum ProfileEditReactorMutation {
   case invaildNickname(message: String)
   case buttonEnable(isEnable: Bool)
   case showIndicator(show: Bool)
-  case setPhotoPermission(isAllow: Bool)
+  case setPhotoPermission(Bool)
   case moveToBack
 }
 

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
@@ -16,6 +16,7 @@ public enum ProfileEditReactorAction {
   case editProfile(nickname: String, profileURL: String)
   case checkCondition(nickname: String)
   case checkPhotoPermission
+  case tapCancelButton
 }
 
 public enum ProfileEditReactorMutation {
@@ -23,6 +24,7 @@ public enum ProfileEditReactorMutation {
   case buttonEnable(isEnable: Bool)
   case showIndicator(show: Bool)
   case setPhotoPermission(isAllow: Bool)
+  case moveToBack
 }
 
 public struct ProfileEditReactorState {

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
@@ -15,18 +15,21 @@ import RxSwift
 public enum ProfileEditReactorAction {
   case editProfile(nickname: String, profileURL: String)
   case checkCondition(nickname: String)
+  case checkPhotoPermission
 }
 
 public enum ProfileEditReactorMutation {
   case invaildNickname(message: String)
   case buttonEnable(isEnable: Bool)
   case showIndicator(show: Bool)
+  case setPhotoPermission(isAllow: Bool)
 }
 
 public struct ProfileEditReactorState {
   public init() { }
   public var buttonEnable: Bool = false
   public var showIndicator: Bool = false
+  public var isGrantedPhoto: Bool = false
   @Pulse public var invaildMessage: String = ""
 }
 


### PR DESCRIPTION
## 📌 개요
#138 
재설치 시 온보딩을 거치지 않아 권한 요청을 하지 않는 오류를 해결했습니다. 

## ✍️ 변경사항
1. MissionView 진입 시 Noitification 권한 검사 및 요청
2. `미션 시작하기` 버튼 클릭 시 Camera 권한 검사 및 요청
3. 프로필 이미지 변경 시 Photo 권한 검사 및 요청

## 📷 스크린샷
|  미션 시작 시 카메라 권한   |  로그인 이후 알림 권한 | 프로필 변경 시 갤러리 권한|
|----------------------------------------------------------|----------------------------------------------------------|----------------------------------------------------------|
| <img src="https://github.com/user-attachments/assets/1bdaa154-ca2f-4aa5-91c1-81da589a3b09" width="300"/> | <img src="https://github.com/user-attachments/assets/c6283842-537a-4e23-a6fc-cb4e92660ea6" width="300"/> | <img src="https://github.com/user-attachments/assets/60bace73-da7e-4d76-b642-187a3b924ea6" width="300"/> |


## 🛠️ **Technical Concerns(기술적 고민)**
