### PR TITLE
토스트 레이아웃 수정

### DIFF
--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
@@ -15,6 +15,8 @@ import MembersDependencyFactory
 import BaseCoordinator
 import MyPageCoordinator
 
+import DesignSystem
+
 import RxSwift
 import RxCocoa
 
@@ -120,6 +122,7 @@ extension MyPageCoordinatorImp {
   
   /// 프로필 설정뷰
   fileprivate func showProfileSettingVC() {
+    
     let reactor = myPageDependencyFactory.injectProfileSettingReactor(
       coordinator: self,
       tokenDeleteUseCase: authDependencyFactory.injectTokenDeleteUseCase(),
@@ -129,6 +132,10 @@ extension MyPageCoordinatorImp {
       kakaoUnlinkUseCase: authDependencyFactory.injectKakaoUnlinkUseCase()
     )
     let ProfileSettingVC = myPageDependencyFactory.injectProfileSettingViewController(reactor: reactor)
+    guard let tabBarViewController = navigationController.tabBarController as? WalWalTabBarViewController else {
+      return
+    }
+    tabBarViewController.hideCustomTabBar()
     self.pushViewController(viewController: ProfileSettingVC, animated: true)
   }
   

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
@@ -51,6 +51,7 @@ public final class WalWalTabBarViewController: UITabBarController {
   
   public override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
+    additionalSafeAreaInsets.bottom = customTabBar.isHidden ? 0 : 68
     containerView.pin
       .bottom()
       .left()

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
@@ -51,7 +51,6 @@ public final class WalWalTabBarViewController: UITabBarController {
   
   public override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    additionalSafeAreaInsets.bottom = customTabBar.isHidden ? 0 : 68
     containerView.pin
       .bottom()
       .left()

--- a/WalWal/Features/Auth/AuthPresenter/Implement/Views/AuthViewImp.swift
+++ b/WalWal/Features/Auth/AuthPresenter/Implement/Views/AuthViewImp.swift
@@ -165,8 +165,7 @@ extension AuthViewControllerImp: View {
       .drive(with: self) { owner, message in
         WalWalToast.shared.show(
           type: .error,
-          message: message,
-          isTabBarExist: false
+          message: message
         )
       }
       .disposed(by: disposeBag)

--- a/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Views/WriteContentDuringTheMissionViewImp.swift
+++ b/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Views/WriteContentDuringTheMissionViewImp.swift
@@ -302,8 +302,7 @@ extension WriteContentDuringTheMissionViewControllerImp: View {
       .drive(onNext: { errorMessage in
         WalWalToast.shared.show(
           type: .error,
-          message: errorMessage,
-          isTabBarExist: false
+          message: errorMessage
         )
       })
       .disposed(by: disposeBag)

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
@@ -14,6 +14,7 @@ import ResourceKit
 import FCMDomain
 import AuthDomain
 import LocalStorage
+import DesignSystem
 
 import ReactorKit
 import RxSwift
@@ -101,6 +102,10 @@ public final class ProfileSettingReactorImp: ProfileSettingReactor {
     case let .setIsRecentVersion(isRecent):
       newState.isRecent = isRecent
     case .moveToBack:
+      guard let tabBarViewController = coordinator.navigationController.tabBarController as? WalWalTabBarViewController else {
+        return state
+      }
+      tabBarViewController.showCustomTabBar()
       coordinator.popViewController(animated: true)
     }
     return newState


### PR DESCRIPTION
## 📌 개요
토스트 뷰 safearea bottom 수정하였습니다.

## ✍️ 변경사항
- 최상위 뷰의 safearea bottom값을 찾아서 토스트 뷰의 하단 값을 설정하였습니다.
- 설정 뷰 진입 시 탭바 Hidden을 적용하였습니다.

## 📷  스크린샷

https://github.com/user-attachments/assets/9acd4129-2e7a-421c-8609-c083f95d3cf6


## 🛠️ **Technical Concerns(기술적 고민)**
키보드가 올라와있을 경우 토스트를 띄워야 할 때, 키보드가 올라와있는지에 대한 여부와 그에 대한 하단 마진 값을 어떻게 해야할지 고민 중입니다.