### PR TITLE
온보딩 화면 수정

### DIFF
--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -190,13 +190,19 @@ extension ProfileEditViewControllerImp: View {
   
   public func bindState(reactor: R) {
     reactor.pulse(\.$isGrantedPhoto)
-      .bind(with: self, onNext: { owner, isAllowed in
+      .asDriver(onErrorJustReturn: false)
+      .skip(1)
+      .drive(with: self) { owner, isAllowed in
         if isAllowed {
           PHPickerManager.shared.presentPicker(vc: owner)
         } else {
-          // TODO: - alert 띄우기
+          WalWalAlert.shared.showOkAlert(
+            title: "앨범에 대한 접근 권한이 없습니다",
+            bodyMessage: "설정 > 왈왈 탭에서 접근을 활성화 할 수 있습니다.",
+            okTitle: "확인"
+          )
         }
-      })
+      }
       .disposed(by: disposeBag)
     
     reactor.state
@@ -228,6 +234,11 @@ extension ProfileEditViewControllerImp: View {
       .drive(with: self) { owner, image in
         owner.profileEditView.selectedImageData.accept(image)
       }
+      .disposed(by: disposeBag)
+    
+    WalWalAlert.shared.resultRelay
+      .map { _ in Void() }
+      .bind(to: WalWalAlert.shared.closeAlert)
       .disposed(by: disposeBag)
   }
 }

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Reactors/OnboardingSelectReactorImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Reactors/OnboardingSelectReactorImp.swift
@@ -36,6 +36,8 @@ public final class OnboardingSelectReactorImp: OnboardingSelectReactor {
     case let .nextButtonTapped(flow):
       coordinator.destination.accept(flow)
       return .never()
+    case .tapBackButton:
+      return .just(.moveToBack)
     }
   }
   
@@ -46,6 +48,8 @@ public final class OnboardingSelectReactorImp: OnboardingSelectReactor {
       newState.selectedAnimal = (dog, cat)
     case let .selectCompleteButtonEnable(isEnable):
       newState.selectCompleteButtonEnable = isEnable
+    case .moveToBack:
+      coordinator.popViewController(animated: true)
     }
     return newState
   }

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/Custom/DescriptionCell.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/Custom/DescriptionCell.swift
@@ -1,0 +1,101 @@
+//
+//  DescriptionCell.swift
+//  OnboardingPresenterImp
+//
+//  Created by Jiyeon on 8/17/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import UIKit
+import ResourceKit
+import DesignSystem
+
+import RxSwift
+import FlexLayout
+import PinLayout
+import Then
+
+struct DescriptionModel: Hashable {
+  var title: String
+  var subTitle: String
+  var image: UIImage
+}
+
+final class DescriptionCell: UICollectionViewCell, ReusableView {
+  private typealias Color = ResourceKitAsset.Colors
+  private typealias Font = ResourceKitFontFamily.KR
+  
+  // MARK: - UI
+  
+  private let mainTitleLabel = UILabel().then {
+    $0.font = Font.H3
+    $0.textColor = Color.black.color
+    $0.numberOfLines = 2
+    $0.textAlignment = .center
+  }
+  private let subTextLabel = UILabel().then {
+    $0.font = Font.B1
+    $0.textColor = Color.gray600.color
+    $0.textAlignment = .center
+  }
+  private let imageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  // MARK: - Initialize
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configAttribute()
+    configLayout()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Layout
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    mainTitleLabel.text = ""
+    subTextLabel.text = ""
+    imageView.image = nil
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    contentView.flex
+      .layout(mode: .adjustHeight)
+  }
+  
+  private func configAttribute() {
+    [mainTitleLabel, subTextLabel, imageView].forEach {
+      contentView.addSubview($0)
+    }
+  }
+  
+  private func configLayout() {
+    contentView.flex
+      .justifyContent(.center)
+      .define {
+        $0.addItem(mainTitleLabel)
+        $0.addItem(subTextLabel)
+          .marginTop(4)
+        $0.addItem(imageView)
+          .alignSelf(.center)
+          .width(100%)
+          .marginTop(8)
+          .aspectRatio(375.adjustedWidth/280.adjustedHeight)
+      }
+  }
+  
+  // MARK: - Method
+  
+  func configData(data: DescriptionModel) {
+    mainTitleLabel.text = data.title
+    subTextLabel.text = data.subTitle
+    imageView.image = data.image
+  }
+  
+}

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/Custom/DescriptionView.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/Custom/DescriptionView.swift
@@ -79,7 +79,7 @@ final class DescriptionView: UIView {
           .alignSelf(.center)
           .marginTop(8)
           .marginHorizontal(8)
-          .aspectRatio(332/249)
+          .aspectRatio(332.adjustedWidth/249.adjustedHeight)
       }
   }
 }

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/Custom/PermissionView.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/Custom/PermissionView.swift
@@ -52,7 +52,7 @@ final class PermissionView {
   private let notiPermissionView = PermissionListView(
     icon: Images.noticeL.image.withTintColor(Color.gray800.color),
     type: "알림",
-    content: "미션 알림 메세지 수신"
+    content: "미션 알림 메시지 수신"
   )
   private let cameraPermissionView = PermissionListView(
     icon: Images.cameraL.image.withTintColor(Color.gray800.color),
@@ -77,16 +77,16 @@ final class PermissionView {
       .marginHorizontal(30.adjustedWidth)
       .define {
         $0.addItem(titleLabel)
-          .marginTop(45.adjustedHeight)
+          .marginTop(44.adjustedHeight)
         
         $0.addItem(contentLabel)
-          .marginTop(8)
+          .marginTop(4)
         
         $0.addItem()
           .direction(.row)
           .justifyContent(.center)
-          .marginTop(40.adjustedHeight)
-          .marginBottom(46.adjustedHeight)
+          .marginTop(37.adjustedHeight)
+          .marginBottom(51.adjustedHeight)
           .define {
             $0.addItem().define {
               $0.addItem(notiPermissionView)
@@ -201,10 +201,10 @@ fileprivate final class PermissionListView: UIView {
           .direction(.row)
           .define {
             $0.addItem(iconImageView)
-              .size(40.adjusted)
+              .size(32.adjusted)
             $0.addItem(typeLabel)
               .marginRight(8)
-              .marginLeft(4)
+              .marginLeft(2)
             $0.addItem(contentLabel)
           }
         

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingProfileViewImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingProfileViewImp.swift
@@ -239,7 +239,7 @@ extension OnboardingProfileViewControllerImp: View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
-    navigationBar.rightItems?.first?.rx.tapped
+    navigationBar.leftItems?.first?.rx.tapped
       .map { Reactor.Action.tapBackButton }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
@@ -293,7 +293,6 @@ extension OnboardingProfileViewControllerImp: View {
       .asDriver()
       .drive(with: self) { owner, _ in
         owner.view.endEditing(true)
-        owner.navigationController?.popViewController(animated: true)
       }
       .disposed(by: disposeBag)
     

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingSelectViewImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingSelectViewImp.swift
@@ -156,14 +156,15 @@ extension OnboardingSelectViewControllerImp: View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
-//    initState
-//      .map { Reactor.Action.initSelectView }
-//      .bind(to: reactor.action)
-//      .disposed(by: disposeBag)
-    
     nextButton.rx.tapped
       .withLatestFrom(selectPetType)
       .map { Reactor.Action.nextButtonTapped(flow: .showProfile(petType: $0))}
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    navigationBar.leftItems?.first?.rx.tapped
+      .debug()
+      .map { Reactor.Action.tapBackButton }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
   }
@@ -210,12 +211,6 @@ extension OnboardingSelectViewControllerImp: View {
       }
       .disposed(by: disposeBag)
     
-    navigationBar.leftItems?.first?.rx.tapped
-      .asDriver()
-      .drive(with: self) { owner, _ in
-        owner.navigationController?.popViewController(animated: true)
-      }
-      .disposed(by: disposeBag)
   }
   
 }

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingSelectViewImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingSelectViewImp.swift
@@ -117,13 +117,11 @@ public final class OnboardingSelectViewControllerImp<R: OnboardingSelectReactor>
           .marginTop(40.adjustedHeight)
         $0.addItem()
           .direction(.row)
-          .justifyContent(.spaceEvenly)
+          .justifyContent(.spaceBetween)
           .marginTop(80.adjustedHeight)
           .define {
             $0.addItem(dogView)
-              .grow(1)
             $0.addItem(catView)
-              .grow(1)
           }
       }
     nextButton.flex

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingViewImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingViewImp.swift
@@ -33,26 +33,33 @@ public final class OnboardingViewControllerImp<R: OnboardingReactor>:
   // MARK: - UI
   
   private let rootContainer = UIView()
-  private let descriptionView1 = DescriptionView(
-    mainTitle: "반려동물과 함께하는\n데일리 미션",
-    subText: "반려동물과 함께 미션을 수행해요",
-    image: Images.onboarding1.image
-  )
-  private let descriptionView2 = DescriptionView(
-    mainTitle: "귀여운 반려동물\n피드에서 모아보세요!",
-    subText: "다양한 반려동물을 한 눈에 발견해요",
-    image: Images.onboarding2.image
-  )
-  private let descriptionView3 = DescriptionView(
-    mainTitle: "매일 수행한 미션\n언제든지 꺼내봐요!",
-    subText: "반려동물과의 함께한 추억을 기억해요",
-    image: Images.onboarding3.image
-  )
-  private lazy var scrollView = UIScrollView().then {
-    $0.isPagingEnabled = true
+  private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout()).then {
+    $0.backgroundColor = Colors.white.color
+    $0.register(DescriptionCell.self)
     $0.showsHorizontalScrollIndicator = false
+    $0.decelerationRate = .fast
+    $0.contentInsetAdjustmentBehavior = .never
+    $0.isPagingEnabled = true
     $0.bounces = false
   }
+  
+  private let cellData: [DescriptionModel] = [
+    .init(
+      title: "반려동물과 함께하는\n데일리 미션",
+      subTitle: "반려동물과 함께 미션을 수행해요",
+      image: Images.onboarding1.image
+    ),
+    .init(
+      title: "귀여운 반려동물\n피드에서 모아보세요!",
+      subTitle: "다양한 반려동물을 한 눈에 발견해요",
+      image: Images.onboarding2.image
+    ),
+    .init(title: "매일 수행한 미션\n언제든지 꺼내봐요!",
+          subTitle: "반려동물과의 함께한 추억을 기억해요",
+          image: Images.onboarding3.image
+         )
+  ]
+  
   private lazy var pageControl = UIPageControl().then {
     $0.numberOfPages = 3
     $0.currentPage = 0
@@ -90,13 +97,6 @@ public final class OnboardingViewControllerImp<R: OnboardingReactor>:
       .all(view.pin.safeArea)
     rootContainer.flex
       .layout()
-    
-    scrollView.contentSize = CGSize(
-      width: scrollView.frame.width * 3,
-      height: scrollView.frame.height
-    )
-    scrollView.flex
-      .layout(mode: .adjustHeight)
   }
   
   public func configureAttribute() {
@@ -112,8 +112,9 @@ public final class OnboardingViewControllerImp<R: OnboardingReactor>:
           .marginBottom(99.adjustedHeight)
           .grow(1)
           .define {
-            $0.addItem(scrollView)
-              .alignSelf(.center)
+            $0.addItem(collectionView)
+              .width(375.adjustedWidth)
+              .height(367.adjustedHeight)
             $0.addItem(pageControl)
               .marginTop(22.adjustedHeight)
               .height(5)
@@ -121,22 +122,16 @@ public final class OnboardingViewControllerImp<R: OnboardingReactor>:
         $0.addItem(nextButton)
           .marginBottom(30.adjustedHeight)
           .marginHorizontal(20)
-          .height(56)
       }
     
-    scrollView.flex
-      .direction(.row)
-      .define {
-        $0.addItem(descriptionView1)
-          .width(100%)
-          .height(80%)
-        $0.addItem(descriptionView2)
-          .width(100%)
-          .height(80%)
-        $0.addItem(descriptionView3)
-          .width(100%)
-          .height(80%)
-      }
+  }
+  
+  private func collectionViewLayout() -> UICollectionViewLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.minimumLineSpacing = 0
+    layout.itemSize = CGSize(width: UIScreen.main.bounds.width, height: 367.adjustedHeight)
+    layout.scrollDirection = .horizontal
+    return layout
   }
 }
 
@@ -161,15 +156,21 @@ extension OnboardingViewControllerImp: View {
   }
   
   public func bindEvent() {
-    scrollView.rx.setDelegate(self)
+    
+    collectionView.rx.contentOffset
+      .withUnretained(self)
+      .map { owner, contentOffset -> Int in
+        guard owner.collectionView.frame.width > 0 else { return 0 }
+        let page = Int(round(contentOffset.x / owner.collectionView.frame.width))
+        return page
+      }
+      .bind(to: pageControl.rx.currentPage)
       .disposed(by: disposeBag)
     
-    scrollView.rx.didScroll
-      .asDriver()
-      .drive(with: self) { owner, _ in
-        guard owner.scrollView.frame.width > 0 else { return }
-        let pageIndex = round(owner.scrollView.contentOffset.x / owner.scrollView.frame.width)
-        owner.pageControl.currentPage = Int(pageIndex)
+    
+    Observable.just(cellData)
+      .bind(to: collectionView.rx.items(DescriptionCell.self)) { index, data, cell in
+        cell.configData(data: data)
       }
       .disposed(by: disposeBag)
   }

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingViewImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingViewImp.swift
@@ -54,10 +54,11 @@ public final class OnboardingViewControllerImp<R: OnboardingReactor>:
       subTitle: "다양한 반려동물을 한 눈에 발견해요",
       image: Images.onboarding2.image
     ),
-    .init(title: "매일 수행한 미션\n언제든지 꺼내봐요!",
-          subTitle: "반려동물과의 함께한 추억을 기억해요",
-          image: Images.onboarding3.image
-         )
+    .init(
+      title: "매일 수행한 미션\n언제든지 꺼내봐요!",
+      subTitle: "반려동물과의 함께한 추억을 기억해요",
+      image: Images.onboarding3.image
+    )
   ]
   
   private lazy var pageControl = UIPageControl().then {

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Interface/Reactors/OnboardingProfileReactor.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Interface/Reactors/OnboardingProfileReactor.swift
@@ -19,6 +19,8 @@ import ReactorKit
 public enum OnboardingProfileReactorAction {
   case register(nickname: String, profile: WalWalProfileModel, petType: String)
   case checkCondition(nickname: String, profile: WalWalProfileModel)
+  case checkPhotoPermission
+  case tapBackButton
 }
 
 public enum OnboardingProfileReactorMutation {
@@ -26,14 +28,18 @@ public enum OnboardingProfileReactorMutation {
   case invalidNickname(message: String)
   case registerError(message: String)
   case showIndicator(show: Bool)
+  case setPhotoPermission(isAllow: Bool)
+  case moveToBack
 }
 
 public struct OnboardingProfileReactorState {
   public init() { }
   @Pulse public var invalidMessage: String = ""
-  public var buttonEnable: Bool = false
+  @Pulse public var isGrantedPhoto: Bool = false
   @Pulse public var errorMessage: String = ""
+  public var buttonEnable: Bool = false
   public var showIndicator: Bool = false
+  
 }
 
 public protocol OnboardingProfileReactor:

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Interface/Reactors/OnboardingSelectReactor.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Interface/Reactors/OnboardingSelectReactor.swift
@@ -14,11 +14,13 @@ import ReactorKit
 public enum OnboardingSelectReactorAction {
   case selectAnimal(dog: Bool, cat: Bool)
   case nextButtonTapped(flow: OnboardingCoordinatorFlow)
+  case tapBackButton
 }
 
 public enum OnboardingSelectReactorMutation {
   case selectAnimal(dog: Bool, cat: Bool)
   case selectCompleteButtonEnable(_ isEnable: Bool)
+  case moveToBack
 }
 
 public struct OnboardingSelectReactorState {


### PR DESCRIPTION
## 📌 개요
온보딩 화면 일부 수정하였습니다.

## ✍️ 변경사항
### 첫 화면 scroll 수정
스크롤 시 다음 화면이 보이지 않는 이슈가 있어서 기존 scrollview에서 collectionview를 사용하는 것으로 변경하였습니다.
### 권한 얼럿 추가
프로필 사진 선택 위해 앨범 접근 시 권한 체크를 한번 더 하였고, 거부하였을 시 얼럿 화면을 띄우는 방식으로 변경하였습니다.
같은 코드가 프로필 수정에서도 사용되어야 하기 때문에 해당 부분에도 추가적으로 구해두었습니다.

### 기타
일부 레이아웃을 수정하였습니다.

## 📷 스크린샷

https://github.com/user-attachments/assets/6ae853c1-a893-4a49-93d1-589883719778



## 🛠️ **Technical Concerns(기술적 고민)**
