### PR TITLE
기타 레이아웃 수정

### DIFF
--- a/WalWal/DesignSystem/Sources/WalWalNavigationBar/WalWalNavigationBar.swift
+++ b/WalWal/DesignSystem/Sources/WalWalNavigationBar/WalWalNavigationBar.swift
@@ -135,7 +135,7 @@ extension WalWalNavigationBar {
                 .marginRight(16)
             }
           }
-          .marginLeft(10)
+          .marginLeft(12)
         
         flex.addItem(self.titleLabel)
           .grow(1)
@@ -152,7 +152,7 @@ extension WalWalNavigationBar {
                 .marginLeft(16)
             }
           }
-          .marginRight(20)
+          .marginRight(12)
       }
   }
   

--- a/WalWal/Features/Auth/AuthDomain/Implement/KakaoLoginManager.swift
+++ b/WalWal/Features/Auth/AuthDomain/Implement/KakaoLoginManager.swift
@@ -33,17 +33,22 @@ final class KakaoLoginManager {
   func kakaoLogin() -> Single<String> {
       return Single<String>.create { single in
           let loginCompletion: (OAuthToken?, Error?) -> Void = { oauthToken, error in
+            
               if let error = error {
                   print("====kakao login error====")
                   single(.failure(error))
               } else if let oauthToken = oauthToken {
                   print("====kakao login success====")
                   single(.success(oauthToken.accessToken))
+              } else {
+                print("ERROR")
+                single(.failure(NSError(domain: "", code: 400)))
               }
           }
         
           if UserApi.isKakaoTalkLoginAvailable() {
               UserApi.shared.loginWithKakaoTalk(completion: loginCompletion)
+            
           } else {
               UserApi.shared.loginWithKakaoAccount(completion: loginCompletion)
           }

--- a/WalWal/Features/Auth/AuthDomain/Implement/KakaoLoginManager.swift
+++ b/WalWal/Features/Auth/AuthDomain/Implement/KakaoLoginManager.swift
@@ -40,9 +40,6 @@ final class KakaoLoginManager {
               } else if let oauthToken = oauthToken {
                   print("====kakao login success====")
                   single(.success(oauthToken.accessToken))
-              } else {
-                print("ERROR")
-                single(.failure(NSError(domain: "", code: 400)))
               }
           }
         

--- a/WalWal/Features/Auth/AuthPresenter/Implement/Reactors/AuthReactorImp.swift
+++ b/WalWal/Features/Auth/AuthPresenter/Implement/Reactors/AuthReactorImp.swift
@@ -67,6 +67,8 @@ public final class AuthReactorImp: AuthReactor {
         .just(.showIndicator(show: true)),
         kakaoLogin()
       ])
+    case let .indicatorState(state):
+      return .just(.showIndicator(show: state))
     }
   }
   

--- a/WalWal/Features/Auth/AuthPresenter/Implement/Views/AuthViewImp.swift
+++ b/WalWal/Features/Auth/AuthPresenter/Implement/Views/AuthViewImp.swift
@@ -156,6 +156,15 @@ extension AuthViewControllerImp: View {
       .map { Reactor.Action.kakaoLoginTapped }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+    
+    NotificationCenter.default.rx.notification(UIApplication.willEnterForegroundNotification)
+      .debug()
+      .map { _ in
+        Reactor.Action.indicatorState(state: false)
+      }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
   }
   
   public func bindState(reactor: R) {

--- a/WalWal/Features/Auth/AuthPresenter/Implement/Views/AuthViewImp.swift
+++ b/WalWal/Features/Auth/AuthPresenter/Implement/Views/AuthViewImp.swift
@@ -158,7 +158,6 @@ extension AuthViewControllerImp: View {
       .disposed(by: disposeBag)
     
     NotificationCenter.default.rx.notification(UIApplication.willEnterForegroundNotification)
-      .debug()
       .map { _ in
         Reactor.Action.indicatorState(state: false)
       }

--- a/WalWal/Features/Auth/AuthPresenter/Interface/Reactors/AuthReactor.swift
+++ b/WalWal/Features/Auth/AuthPresenter/Interface/Reactors/AuthReactor.swift
@@ -18,6 +18,7 @@ import RxSwift
 public enum AuthReactorAction {
   case appleLoginTapped(authCode: String)
   case kakaoLoginTapped
+  case indicatorState(state: Bool)
 }
 
 public enum AuthReactorMutation {

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
@@ -39,7 +39,6 @@ public final class BubbleView: UIView {
   private var tipHeight: CGFloat = 16
   public var missionCount = BehaviorRelay<Int>(value: 0)
   public var isCompleted = BehaviorRelay<Bool>(value: false)
-  
   private let disposeBag = DisposeBag()
   
   // MARK: - Initializers
@@ -60,7 +59,12 @@ public final class BubbleView: UIView {
   
   override public func layoutSubviews() {
     super.layoutSubviews()
-    configureAttribute()
+    layer.cornerRadius = containerView.bounds.height / 2
+    containerView.pin
+      .all()
+    containerView.flex
+      .layout()
+    
     setTipShape(viewColor: self.backgroundColor ?? .clear, tipWidth: tipWidth, tipHeight: tipHeight)
   }
   
@@ -70,16 +74,10 @@ public final class BubbleView: UIView {
     return false 
   }
   
-  
   private func configureAttribute() {
     self.addSubview(containerView)
-    containerView.pin
-      .all()
-    titleLabel.sizeToFit()
-    containerView.flex
-      .markDirty()
-    containerView.flex.layout(mode: .adjustWidth)
-    layer.cornerRadius = containerView.bounds.height / 2
+    containerView.addSubview(iconImageView)
+    containerView.addSubview(titleLabel)
   }
   
   private func configureLayout() {
@@ -87,15 +85,14 @@ public final class BubbleView: UIView {
       .direction(.row)
       .alignItems(.center)
       .justifyContent(.center)
-      .padding(9.5, 20)
-      .define {
-        if iconImageView.image != nil {
-          $0.addItem(iconImageView)
-            .marginRight(4)
-        }
-        $0.addItem(titleLabel)
-          .height(19)
-      }
+      .paddingVertical(9.5)
+      .shrink(1)
+    
+    iconImageView.flex
+      .marginRight(4)
+      .marginLeft(20)
+    titleLabel.flex
+      .marginRight(20)
   }
   
   private func bind() {
@@ -104,12 +101,12 @@ public final class BubbleView: UIView {
       .bind(with: self) { owner, data in
         let (count, completed) = data
         owner.titleLabel.text = completed ? "\(count)번째 함께 미션을 완료했어요!" : "\(count+1)번째 미션을 함께 수행해볼까요?"
+        owner.titleLabel.flex.markDirty()
+        owner.containerView.flex.markDirty()
         owner.setNeedsLayout()
       }
       .disposed(by: disposeBag)
-    
   }
-  
   
   private func setTipShape(viewColor: UIColor, tipWidth: CGFloat, tipHeight: CGFloat) {
     let tipStartX = (containerView.bounds.width - tipWidth) / 2.0

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
@@ -75,11 +75,10 @@ public final class BubbleView: UIView {
     self.addSubview(containerView)
     containerView.pin
       .all()
-    containerView.pin.left().top().right()
-
     titleLabel.sizeToFit()
     containerView.flex
       .markDirty()
+    containerView.flex.layout(mode: .adjustWidth)
     layer.cornerRadius = containerView.bounds.height / 2
   }
   

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
@@ -30,7 +30,7 @@ public final class BubbleView: UIView {
   private let titleLabel = UILabel().then {
     $0.textColor = Colors.walwalOrange.color
     $0.font = Fonts.KR.H6.B
-    $0.numberOfLines = 0
+    $0.numberOfLines = 1
   }
   
   // MARK: - Property
@@ -75,6 +75,8 @@ public final class BubbleView: UIView {
     self.addSubview(containerView)
     containerView.pin
       .all()
+    containerView.pin.left().top().right()
+
     titleLabel.sizeToFit()
     containerView.flex
       .markDirty()
@@ -99,11 +101,14 @@ public final class BubbleView: UIView {
   
   private func bind() {
     Observable.combineLatest(missionCount, isCompleted)
-      .map { count, completed -> String in
-        return completed ? "\(count)번째 함께 미션을 완료했어요!" : "\(count+1)번째 미션을 함께 수행해볼까요?"
+      .observe(on: MainScheduler.instance)
+      .bind(with: self) { owner, data in
+        let (count, completed) = data
+        owner.titleLabel.text = completed ? "\(count)번째 함께 미션을 완료했어요!" : "\(count+1)번째 미션을 함께 수행해볼까요?"
+        owner.setNeedsLayout()
       }
-      .bind(to: titleLabel.rx.text)
       .disposed(by: disposeBag)
+    
   }
   
   
@@ -127,9 +132,7 @@ public final class BubbleView: UIView {
     let shape = CAShapeLayer()
     shape.path = path
     shape.fillColor = viewColor.cgColor
-    
     self.layer.insertSublayer(shape, at: 0)
-    
   }
   
   func startFloatingAnimation() {

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -70,6 +70,10 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
     super.viewDidAppear(animated)
     
     missionCountBubbleView.startFloatingAnimation()
+    
+    DispatchQueue.main.asyncAfter(deadline: .now()+3) {
+      self.missionCountBubbleView.missionCount.accept(305)
+    }
   }
   
   public override func viewDidLoad() {
@@ -166,7 +170,6 @@ extension MissionViewControllerImp: View {
         
         owner.isMissionCompleted = state.isMissionStarted
         owner.missionCountBubbleView.isCompleted.accept(state.missionStatus?.statusMessage == .completed)
-        
         owner.missionStartButton.title = state.buttonText
         if let status = state.missionStatus {
           owner.recordImageURL = status.imageUrl

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -71,9 +71,6 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
     
     missionCountBubbleView.startFloatingAnimation()
     
-    DispatchQueue.main.asyncAfter(deadline: .now()+3) {
-      self.missionCountBubbleView.missionCount.accept(305)
-    }
   }
   
   public override func viewDidLoad() {

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
@@ -246,21 +246,18 @@ extension ProfileSettingReactorImp {
     return [
       .init(
         title: "로그아웃",
-        iconImage: Images.logout.image,
         subTitle: "",
         rightText: "",
         type: .logout
       ),
       .init(
         title: "버전 정보",
-        iconImage: Images.swap.image,
         subTitle: appVersion,
         rightText: isRecent ? "최신 버전입니다." : "업데이트 필요",
         type: .version
       ),
       .init(
         title: "회원 탈퇴",
-        iconImage: Images.xSquare.image,
         subTitle: "",
         rightText: "",
         type: .withdraw

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
@@ -182,10 +182,6 @@ extension ProfileSettingReactorImp {
           .just(.moveToAuth)
         ])
       }
-      .catch { error in
-        print(error.localizedDescription)
-        return .just(.setLoading(false))
-      }
   }
   
   

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/DataSource/ProfileSettingTableViewCell.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/DataSource/ProfileSettingTableViewCell.swift
@@ -24,9 +24,8 @@ final class ProfileSettingTableViewCell: UITableViewCell, ReusableView {
   // MARK: - UI
   
   private let containerView = UIView()
-  private let iconImageView = UIImageView()
   private let titleLabel = UILabel().then {
-    $0.font = FontKR.H7.M
+    $0.font = FontKR.H6.M
     $0.textColor = AssetColor.gray700.color
   }
   private let subTitleLabel = UILabel().then {
@@ -59,6 +58,7 @@ final class ProfileSettingTableViewCell: UITableViewCell, ReusableView {
   }
   
   override func prepareForReuse() {
+    super.prepareForReuse()
     resetCell()
   }
   
@@ -69,54 +69,45 @@ final class ProfileSettingTableViewCell: UITableViewCell, ReusableView {
   
   private func setLayout() {
     contentView.addSubview(containerView)
-    [iconImageView, titleLabel, subTitleLabel, rightLabel].forEach {
-      containerView.addSubview($0)
-    }
     
     containerView.flex
       .direction(.row)
+      .justifyContent(.spaceBetween)
       .alignItems(.center)
       .define {
-        $0.addItem(iconImageView)
-          .size(22)
-          .marginLeft(20)
+        $0.addItem(titleLabel)
+          .marginLeft(30)
+        
         $0.addItem()
           .direction(.row)
           .alignItems(.center)
-          .grow(1)
-          .marginLeft(6)
           .define {
-            $0.addItem(titleLabel)
-              .minWidth(58)
             $0.addItem(subTitleLabel)
-              .minWidth(21)
-              .marginLeft(20)
+              .marginRight(4)
+            $0.addItem(rightLabel)
+              .marginRight(19)
           }
-        $0.addItem(rightLabel)
-          .minWidth(80)
-          .marginRight(19)
-          .alignSelf(.center)
       }
   }
   
   private func resetCell() {
-    iconImageView.image = nil
     titleLabel.text = nil
     subTitleLabel.text = nil
     rightLabel.text = nil
   }
   
   func configureCell(
-    iconImage: UIImage?,
     title: String,
     subTitle: String,
     rightText: String
   ) {
-    iconImageView.image = iconImage
     titleLabel.text = title
+    titleLabel.flex.markDirty()
+    
     subTitleLabel.text = subTitle.isEmpty ? " " : subTitle
+    subTitleLabel.flex.markDirty()
+    
     rightLabel.text = rightText.isEmpty ? " " : rightText
-    
-    
+    rightLabel.flex.markDirty()
   }
 }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
@@ -88,11 +88,9 @@ public final class MyPageViewControllerImp<R: MyPageReactor>: UIViewController, 
   
   public override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    containerView
-      .pin
+    containerView.pin
       .all(view.pin.safeArea)
-    containerView
-      .flex
+    containerView.flex
       .layout()
   }
   
@@ -107,14 +105,17 @@ public final class MyPageViewControllerImp<R: MyPageReactor>: UIViewController, 
     view.addSubview(containerView)
     
     containerView.flex
-      .direction(.column)
       .justifyContent(.spaceBetween)
       .define { flex in
         flex.addItem(navigationBar)
         flex.addItem(seperator)
           .height(1)
           .width(100%)
-        flex.addItem(calendar)
+        flex.addItem()
+          .grow(1)
+          .define {
+            $0.addItem(calendar)
+          }
         flex.addItem(profileCardView)
       }
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -29,10 +29,10 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
   // MARK: - UI
   
   private let rootContainerView = UIView().then {
-    $0.backgroundColor = Colors.gray150.color
+    $0.backgroundColor = Colors.gray100.color
   }
   private let profileContainer = UIView().then {
-    $0.backgroundColor = Colors.gray150.color
+    $0.backgroundColor = Colors.gray100.color
   }
   private let navigationBarView = WalWalNavigationBar(
     leftItems: [],
@@ -41,6 +41,9 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
     rightItemSize: 40
   ).then {
     $0.backgroundColor = Colors.white.color
+  }
+  private let seperator = UIView().then {
+    $0.backgroundColor = Colors.gray150.color
   }
   private var profileEditView: WalWalProfile
   private let nicknameTextfield = WalWalInputBox(
@@ -114,6 +117,8 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
       .justifyContent(.spaceBetween)
       .define {
         $0.addItem(navigationBarView)
+        $0.addItem(seperator)
+          .height(1)
           .width(100%)
         $0.addItem(profileContainer)
           .justifyContent(.center)

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
@@ -138,7 +138,6 @@ extension ProfileSettingViewControllerImp: View {
       .bind(to: settingTableView.rx
         .items(ProfileSettingTableViewCell.self)) { row, model, cell in
           cell.configureCell(
-            iconImage: model.iconImage,
             title: model.title,
             subTitle: model.subTitle,
             rightText: model.rightText

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/ProfileSettingItemModel.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/ProfileSettingItemModel.swift
@@ -1,0 +1,36 @@
+//
+//  ProfileSettingItemModel.swift
+//  MyPagePresenter
+//
+//  Created by Jiyeon on 8/23/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import UIKit
+
+public struct ProfileSettingItemModel {
+  public let title: String
+  public let iconImage: UIImage?
+  public let subTitle: String
+  public let rightText: String
+  public let type: SettingType
+  
+  public init(title: String,
+              iconImage: UIImage?,
+              subTitle: String,
+              rightText: String,
+              type: SettingType
+  ) {
+    self.title = title
+    self.iconImage = iconImage
+    self.subTitle = subTitle
+    self.rightText = rightText
+    self.type = type
+  }
+}
+
+public enum SettingType {
+  case logout
+  case version
+  case withdraw
+}

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/ProfileSettingItemModel.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/ProfileSettingItemModel.swift
@@ -10,19 +10,16 @@ import UIKit
 
 public struct ProfileSettingItemModel {
   public let title: String
-  public let iconImage: UIImage?
   public let subTitle: String
   public let rightText: String
   public let type: SettingType
   
   public init(title: String,
-              iconImage: UIImage?,
               subTitle: String,
               rightText: String,
               type: SettingType
   ) {
     self.title = title
-    self.iconImage = iconImage
     self.subTitle = subTitle
     self.rightText = rightText
     self.type = type

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileSettingReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileSettingReactor.swift
@@ -15,30 +15,11 @@ import AuthDomain
 import ReactorKit
 import RxSwift
 
-
-// Cell 구성 모델
-public struct ProfileSettingItemModel {
-  public let title: String
-  public let iconImage: UIImage?
-  public let subTitle: String
-  public let rightText: String
-  
-  public init(title: String,
-              iconImage: UIImage?,
-              subTitle: String,
-              rightText: String) {
-    self.title = title
-    self.iconImage = iconImage
-    self.subTitle = subTitle
-    self.rightText = rightText
-  }
-}
-
-
 public enum ProfileSettingReactorAction {
   
   case viewDidLoad
-  case didSelectItem(at: IndexPath)
+  case logout
+  case withdraw
   case tapBackButton
 }
 


### PR DESCRIPTION
## 📌 개요
여러 작은 레이아웃 오류 및 추가사항 구현

## ✍️ 변경사항
### 버블뷰 레이아웃 오류 수정
텍스트가 변경됨에 따라 텍스트 잘리는 오류 수정
버블 뷰 타이틀 값이 변경될 때 레이아웃을 다시 설정하도록 구현
```swift
Observable.combineLatest(missionCount, isCompleted)
      .observe(on: MainScheduler.instance)
      .bind(with: self) { owner, data in
        let (count, completed) = data
        owner.titleLabel.text = completed ? "\(count)번째 함께 미션을 완료했어요!" : "\(count+1)번째 미션을 함께 수행해볼까요?"
        owner.titleLabel.flex.markDirty()
        owner.containerView.flex.markDirty()
        owner.setNeedsLayout()
      }
      .disposed(by: disposeBag)
  }
```
### 마이페이지 레이아웃 오류 수정
기존에 마이페이지 화면에서 백그라운드로 나갔다가 돌아올 때 레이아웃이 망가지는 오류 존재
-> 캘린더 뷰를 한번 더 감싸고, 감싼 뷰에 grow(1) 적용
```swift

  containerView.flex
    .justifyContent(.spaceBetween)
    .define { flex in
      flex.addItem(navigationBar)
      flex.addItem(seperator)
        .height(1)
        .width(100%)
      flex.addItem()
        .grow(1)
        .define {
          $0.addItem(calendar)
        }
      flex.addItem(profileCardView)
    }
```
### SettingView 레이아웃 수정
UI 변경사항 수정
기존 설정 화면에서 다른 셀 터치 시 버전 정보 셀이 축소되는 문제 발생
셀에 이벤트가 생길 때 마다 layoutsubview가 호출되어 레이아웃에 문제가 생기는 것으로 판단하였고, `configureCell`에서 각 요소에 `flex.markDirty()`를 적용

### 그 외 
- 회원탈퇴 얼럿 추가
- 기타 레이아웃 수정

## 📷 스크린샷
|  수정 된 버블 뷰 | 마이페이지 레이아웃 | 수정된 설정 뷰 및 탈퇴 얼럿 |
| :-------------: | :----------: | :----------: | 
| <img src ="https://github.com/user-attachments/assets/c8f80286-4edb-45fb-8cb7-c0d1eb67a68a" width = "371"> |<img src ="https://github.com/user-attachments/assets/3c293293-5559-43f7-96ac-929506e9b1ed" width = "371"> | <img src ="https://github.com/user-attachments/assets/49d545a9-ecb7-40dd-8ca6-86e1f803e3d0" width = "371"> |


## 🛠️ **Technical Concerns(기술적 고민)**
