### PR TITLE
마이페이지 기타 로직 수정

### DIFF
--- a/WalWal/Features/Auth/AuthPresenter/Implement/Reactors/AuthReactorImp.swift
+++ b/WalWal/Features/Auth/AuthPresenter/Implement/Reactors/AuthReactorImp.swift
@@ -124,7 +124,8 @@ extension AuthReactorImp {
     return saveFCMToken()
       .withUnretained(self)
       .flatMap { owner, _ in
-        owner.checkRecordCalendar()
+        GlobalState.shared.resetRecords()
+        return owner.checkRecordCalendar()
       }
       .withUnretained(self)
       .flatMap { owner, _ in

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
@@ -128,13 +128,11 @@ public final class MissionReactorImp: MissionReactor {
             .map { status in
               return Mutation.setMissionStatus(status)
             }
-            .startWith(mutation)
         }
         return Observable.just(mutation)
       }
       .flatMap { mutation -> Observable<Mutation> in
         return self.fetchMissionCount()
-          .startWith(mutation)
       }
   }
   

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
@@ -96,6 +96,7 @@ public final class ProfileSettingReactorImp: ProfileSettingReactor {
     case let .setSettingItemModel(setting):
       newState.settings = setting
     case .moveToAuth:
+      GlobalState.shared.resetRecords()
       coordinator.startAuth()
     case let .setIsRecentVersion(isRecent):
       newState.isRecent = isRecent

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
@@ -106,6 +106,8 @@ public final class ProfileSettingReactorImp: ProfileSettingReactor {
       }
       tabBarViewController.showCustomTabBar()
       coordinator.popViewController(animated: true)
+    case let .errorMessage(msg):
+      newState.errorMessage = msg
     }
     return newState
   }
@@ -154,6 +156,7 @@ extension ProfileSettingReactorImp {
           .flatMap { _ -> Observable<Mutation> in
             return .concat([
               .just(.setLoading(false)),
+              .just(.errorMessage(msg: "탈퇴를 완료하지 못했어요")),
               .just(.moveToAuth)
             ])
           }
@@ -207,6 +210,7 @@ extension ProfileSettingReactorImp {
         let _ = self.tokenDeleteUseCase.execute()
         return .concat([
           .just(.setLoading(false)),
+          .just(.errorMessage(msg: "탈퇴를 완료하지 못했어요")),
           .just(.moveToAuth)
         ])
       }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileSettingReactorImp.swift
@@ -156,8 +156,7 @@ extension ProfileSettingReactorImp {
           .flatMap { _ -> Observable<Mutation> in
             return .concat([
               .just(.setLoading(false)),
-              .just(.errorMessage(msg: "탈퇴를 완료하지 못했어요")),
-              .just(.moveToAuth)
+              .just(.errorMessage(msg: "탈퇴를 완료하지 못했어요"))
             ])
           }
       }
@@ -210,8 +209,7 @@ extension ProfileSettingReactorImp {
         let _ = self.tokenDeleteUseCase.execute()
         return .concat([
           .just(.setLoading(false)),
-          .just(.errorMessage(msg: "탈퇴를 완료하지 못했어요")),
-          .just(.moveToAuth)
+          .just(.errorMessage(msg: "탈퇴를 완료하지 못했어요"))
         ])
       }
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileEditViewImp.swift
@@ -152,6 +152,7 @@ public final class ProfileEditViewControllerImp<R: ProfileEditReactor>: UIViewCo
     
     nicknameTextfield.flex
       .marginTop(45.adjusted)
+      .height(72)
     
     rootContainerView.flex.layout()
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
@@ -153,6 +153,14 @@ extension ProfileSettingViewControllerImp: View {
         ActivityIndicator.shared.showIndicator.accept(show)
       }
       .disposed(by: disposeBag)
+    
+    reactor.pulse(\.$errorMessage)
+      .asDriver(onErrorJustReturn: "")
+      .compactMap { $0 }
+      .drive(with: self) { owner, message in
+        WalWalToast.shared.show(type: .error, message: message)
+      }
+      .disposed(by: disposeBag)
   }
   
   public func bindEvent() {

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileSettingReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileSettingReactor.swift
@@ -30,6 +30,7 @@ public enum ProfileSettingReactorMutation {
   case setSettingItemModel([ProfileSettingItemModel])
   case moveToAuth
   case moveToBack
+  case errorMessage(msg: String)
 }
 
 public struct ProfileSettingReactorState {
@@ -37,6 +38,7 @@ public struct ProfileSettingReactorState {
   public var appVersionString: String
   public var isRecent: Bool
   public var settings: [ProfileSettingItemModel]
+  @Pulse public var errorMessage: String?
   
   public init(
     isLoading: Bool = false,


### PR DESCRIPTION
## 📌 개요
마이페이지 수정

## ✍️ 변경사항
- 닉네임 입력 시 글자 수 제한과 에러 메세지 출력 부분이 누락되어 추가하였습니다.
- 로그아웃 또는 탈퇴 global state 이미지 데이터를 삭제하도록 구현하였습니다. 
- 탈퇴 시 오류 발생으로 탈퇴가 완료되지 않았을 경우 사용자에게 오류를 알리기 위해 토스트 메세지를 보여주도록 하였습니다.

## 📷 스크린샷
| 탈퇴 실패 토스트 | 닉네임 오류 메세지 |
|:------:|:------:|
| <img src = "https://github.com/user-attachments/assets/890bf08e-fde9-4490-b4b6-b66590a4b463" width = "317">|<img src = "https://github.com/user-attachments/assets/0b2d1d92-08c2-4586-9fef-08d031de89cc" width = "317">|

## 🛠️ **Technical Concerns(기술적 고민)**
x