### PR TITLE
피드 셀, 버블뷰 레이아웃 이슈 해결

### DIFF
--- a/WalWal/DesignSystem/Sources/WalWalFeed/Component/WalWalFeedCellView.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/Component/WalWalFeedCellView.swift
@@ -222,7 +222,6 @@ final class WalWalFeedCellView: UIView {
           .size(40)
         $0.addItem(profileInfoView)
           .marginLeft(10)
-          .width(180)
       }
     
     profileInfoView.flex

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
@@ -34,7 +34,7 @@ public final class BubbleView: UIView {
   }
   
   // MARK: - Property
-  
+  private var tipView: CAShapeLayer? = nil
   private var tipWidth: CGFloat = 16
   private var tipHeight: CGFloat = 16
   public var missionCount = BehaviorRelay<Int>(value: 0)
@@ -127,8 +127,13 @@ public final class BubbleView: UIView {
     
     let shape = CAShapeLayer()
     shape.path = path
-    shape.fillColor = viewColor.cgColor
-    self.layer.insertSublayer(shape, at: 0)
+    shape.fillColor = viewColor.cgColor   
+    if tipView == nil {
+      tipView = shape
+      self.layer.insertSublayer(shape, at: 0)
+    } else {
+      tipView?.path = path
+    }
   }
   
   func startFloatingAnimation() {

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -77,7 +77,15 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
   public override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     missionCountBubbleView.startFloatingAnimation()
+    setupNotificationObservers()
   }
+  
+  public override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    missionCountBubbleView.stopFloatingAnimation()
+    removeNotificationObservers()
+  }
+  
   
   public override func viewDidLoad() {
     super.viewDidLoad()
@@ -197,6 +205,40 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
     let isCompleted = status == .completed ? true : false
     missionCountBubbleView.isCompleted.accept(isCompleted)
   }
+  
+  // MARK: - Notification Setup
+  
+  private func setupNotificationObservers() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(appDidEnterBackground),
+      name: UIApplication.didEnterBackgroundNotification,
+      object: nil
+    )
+    
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(appWillEnterForeground),
+      name: UIApplication.willEnterForegroundNotification,
+      object: nil
+    )
+  }
+  
+  private func removeNotificationObservers() {
+    NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
+    NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+  }
+  
+  // MARK: - Notification Handlers
+  
+  @objc private func appDidEnterBackground() {
+    missionCountBubbleView.stopFloatingAnimation()
+  }
+  
+  @objc private func appWillEnterForeground() {
+    missionCountBubbleView.startFloatingAnimation()
+  }
+  
 }
 
 extension MissionViewControllerImp: View {


### PR DESCRIPTION
## 📌 개요
QA 도중 나온 레이아웃 이슈 해결

## ✍️ 변경사항
1. 피드셀 내의 완료 미션이 잘려서 나오는 이슈 해결
2. 버블뷰가 백그라운드에서 돌아왔을 때 멈추는 현상, 말풍선 tip이 2개 되는 현상 해결

## 📷 스크린샷
| 버블뷰 이슈 | 피드 셀 |
|:---:|:---:|
| ![RPReplay_Final1724586110](https://github.com/user-attachments/assets/7436e462-c90f-4778-af8e-2ffa3711c0ec) |<img src ="https://github.com/user-attachments/assets/4cf78133-7e95-427b-87bf-056f7cf8bc1c" width = "375px"/>|

## 🛠️ **Technical Concerns(기술적 고민)**
