### PR TITLE
미션수행 완료 후 global state에 저장

### DIFF
--- a/WalWal/Coordinators/App/AppCoordinator/Implement/AppCoordinatorImp.swift
+++ b/WalWal/Coordinators/App/AppCoordinator/Implement/AppCoordinatorImp.swift
@@ -120,16 +120,12 @@ public final class AppCoordinatorImp: AppCoordinator {
     let checkTokenUseCase = appDependencyFactory.injectCheckTokenUseCase()
     let checkIsFirstLoadedUseCase = appDependencyFactory.injectCheckIsFirstLoadedUseCase()
     let fcmSaveUseCase = fcmDependencyFactory.injectFCMSaveUseCase()
-    let checkRecordCalendarUseCase = recordsDependencyFactory.injectCheckCalendarRecordsUseCase()
-    let removeGlobalCalendarRecordsUseCase = recordsDependencyFactory.injectRemoveGlobalCalendarRecordsUseCase()
     let memberInfoUseCase = memberDependencyFactory.injectMemberInfoUseCase()
     let reactor = appDependencyFactory.injectSplashReactor(
       coordinator: self,
       checkTokenUseCase: checkTokenUseCase,
       checkIsFirstLoadedUseCase: checkIsFirstLoadedUseCase,
       fcmSaveUseCase: fcmSaveUseCase,
-      checkRecordCalendarUseCase: checkRecordCalendarUseCase,
-      removeGlobalCalendarRecordsUseCase: removeGlobalCalendarRecordsUseCase,
       memberInfoUseCase: memberInfoUseCase
     )
     let splashVC = appDependencyFactory.injectSplashViewController(reactor: reactor)

--- a/WalWal/Coordinators/App/AppCoordinator/Implement/AppCoordinatorImp.swift
+++ b/WalWal/Coordinators/App/AppCoordinator/Implement/AppCoordinatorImp.swift
@@ -187,7 +187,6 @@ extension AppCoordinatorImp {
       navigationController: navigationController,
       parentCoordinator: self,
       fcmDependencyFactory: fcmDependencyFactory,
-      recordsDependencyFactory: recordsDependencyFactory,
       membersDependencyFactory: memberDependencyFactory
     )
     childCoordinator = authCoordinator

--- a/WalWal/Coordinators/Auth/AuthCoordinator/Implement/AuthCoordinatorImp.swift
+++ b/WalWal/Coordinators/Auth/AuthCoordinator/Implement/AuthCoordinatorImp.swift
@@ -67,8 +67,6 @@ public final class AuthCoordinatorImp: AuthCoordinator {
     let fcmSaveUseCase = fcmDependencyFactory.injectFCMSaveUseCase()
     let userTokensSaveUseCase = authDependencyFactory.injectUserTokensUseCase()
     let kakaoLoginUseCase = authDependencyFactory.injectKakaoLoginUseCase()
-    let checkRecordCalendarUseCase = recordsDependencyFactory.injectCheckCalendarRecordsUseCase()
-    let removeGlobalCalendarRecordsUseCase = recordsDependencyFactory.injectRemoveGlobalCalendarRecordsUseCase()
     let memberInfoUseCase = membersDependencyFactory.injectMemberInfoUseCase()
     
     let reactor = authDependencyFactory.injectAuthReactor(
@@ -77,8 +75,6 @@ public final class AuthCoordinatorImp: AuthCoordinator {
       fcmSaveUseCase: fcmSaveUseCase,
       userTokensSaveUseCase: userTokensSaveUseCase,
       kakaoLoginUseCase: kakaoLoginUseCase,
-      checkRecordCalendarUseCase: checkRecordCalendarUseCase,
-      removeGlobalCalendarRecordsUseCase: removeGlobalCalendarRecordsUseCase,
       memberInfoUseCase: memberInfoUseCase
     )
     let authVC = authDependencyFactory.injectAuthViewController(reactor: reactor)

--- a/WalWal/Coordinators/Auth/AuthCoordinator/Implement/AuthCoordinatorImp.swift
+++ b/WalWal/Coordinators/Auth/AuthCoordinator/Implement/AuthCoordinatorImp.swift
@@ -32,7 +32,6 @@ public final class AuthCoordinatorImp: AuthCoordinator {
   
   private let authDependencyFactory: AuthDependencyFactory
   private let fcmDependencyFactory: FCMDependencyFactory
-  private let recordsDependencyFactory: RecordsDependencyFactory
   private let membersDependencyFactory: MembersDependencyFactory
   
   public required init(
@@ -40,14 +39,12 @@ public final class AuthCoordinatorImp: AuthCoordinator {
     parentCoordinator: (any BaseCoordinator)?,
     authDependencyFactory: AuthDependencyFactory,
     fcmDependencyFactory: FCMDependencyFactory,
-    recordsDependencyFactory: RecordsDependencyFactory,
     membersDependencyFactory: MembersDependencyFactory
   ) {
     self.navigationController = navigationController
     self.parentCoordinator = parentCoordinator
     self.authDependencyFactory = authDependencyFactory
     self.fcmDependencyFactory = fcmDependencyFactory
-    self.recordsDependencyFactory = recordsDependencyFactory
     self.membersDependencyFactory = membersDependencyFactory
     bindChildToParentAction()
     bindState()

--- a/WalWal/Coordinators/Mission/MissionCoordinator/Implement/MissionCoordinatorImp.swift
+++ b/WalWal/Coordinators/Mission/MissionCoordinator/Implement/MissionCoordinatorImp.swift
@@ -86,6 +86,8 @@ public final class MissionCoordinatorImp: MissionCoordinator {
       todayMissionUseCase: missionDependencyFactory.injectTodayMissionUseCase(),
       checkCompletedTotalRecordsUseCase: recordDependencyFactory.injectCheckCompletedTotalRecordsUseCase(),
       checkRecordStatusUseCase: recordDependencyFactory.injectCheckRecordStatusUseCase(),
+      checkRecordCalendarUseCase: recordDependencyFactory.injectCheckCalendarRecordsUseCase(),
+      removeGlobalCalendarRecordsUseCase: recordDependencyFactory.injectRemoveGlobalCalendarRecordsUseCase(),
       startRecordUseCase: recordDependencyFactory.injectStartRecordUseCase()
     )
     let missionVC = missionDependencyFactory.injectMissionViewController(reactor: reactor)

--- a/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Implement/AuthDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Implement/AuthDependencyFactoryImp.swift
@@ -92,8 +92,6 @@ public class AuthDependencyFactoryImp: AuthDependencyFactory {
     fcmSaveUseCase: FCMSaveUseCase,
     userTokensSaveUseCase: UserTokensSaveUseCase,
     kakaoLoginUseCase: KakaoLoginUseCase,
-    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
-    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     memberInfoUseCase: MemberInfoUseCase
   ) -> any AuthReactor {
     return AuthReactorImp(
@@ -102,8 +100,6 @@ public class AuthDependencyFactoryImp: AuthDependencyFactory {
       fcmSaveUseCase: fcmSaveUseCase,
       userTokensSaveUseCase: userTokensSaveUseCase,
       kakaoLoginUseCase: kakaoLoginUseCase,
-      checkRecordCalendarUseCase: checkRecordCalendarUseCase,
-      removeGlobalCalendarRecordsUseCase: removeGlobalCalendarRecordsUseCase,
       memberInfoUseCase: memberInfoUseCase
     )
   }

--- a/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Implement/AuthDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Implement/AuthDependencyFactoryImp.swift
@@ -37,7 +37,6 @@ public class AuthDependencyFactoryImp: AuthDependencyFactory {
     navigationController: UINavigationController,
     parentCoordinator: any BaseCoordinator,
     fcmDependencyFactory: FCMDependencyFactory,
-    recordsDependencyFactory: RecordsDependencyFactory,
     membersDependencyFactory: MembersDependencyFactory
   ) -> any AuthCoordinator {
     return AuthCoordinatorImp(
@@ -45,7 +44,6 @@ public class AuthDependencyFactoryImp: AuthDependencyFactory {
       parentCoordinator: parentCoordinator,
       authDependencyFactory: self,
       fcmDependencyFactory: fcmDependencyFactory,
-      recordsDependencyFactory: recordsDependencyFactory,
       membersDependencyFactory: membersDependencyFactory
     )
   }

--- a/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Interface/AuthDependencyFactory.swift
+++ b/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Interface/AuthDependencyFactory.swift
@@ -26,7 +26,6 @@ public protocol AuthDependencyFactory {
     navigationController: UINavigationController,
     parentCoordinator: any BaseCoordinator,
     fcmDependencyFactory: FCMDependencyFactory,
-    recordsDependencyFactory: RecordsDependencyFactory,
     membersDependencyFactory: MembersDependencyFactory
   ) -> any AuthCoordinator
   

--- a/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Interface/AuthDependencyFactory.swift
+++ b/WalWal/DependencyFactory/Auth/AuthDependencyFactory/Interface/AuthDependencyFactory.swift
@@ -46,8 +46,6 @@ public protocol AuthDependencyFactory {
     fcmSaveUseCase: FCMSaveUseCase,
     userTokensSaveUseCase: UserTokensSaveUseCase,
     kakaoLoginUseCase: KakaoLoginUseCase,
-    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
-    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     memberInfoUseCase: MemberInfoUseCase
   ) -> any AuthReactor
   func injectAuthViewController<T: AuthReactor>(reactor: T) -> any AuthViewController

--- a/WalWal/DependencyFactory/Mission/MissionDependencyFactory/Implement/MissionDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/Mission/MissionDependencyFactory/Implement/MissionDependencyFactoryImp.swift
@@ -65,6 +65,8 @@ public class MissionDependencyFactoryImp: MissionDependencyFactory {
     todayMissionUseCase: TodayMissionUseCase,
     checkCompletedTotalRecordsUseCase: CheckCompletedTotalRecordsUseCase,
     checkRecordStatusUseCase: CheckRecordStatusUseCase,
+    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
+    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     startRecordUseCase: StartRecordUseCase
   ) -> any MissionReactor where T : MissionCoordinator {
     return MissionReactorImp(
@@ -72,6 +74,8 @@ public class MissionDependencyFactoryImp: MissionDependencyFactory {
       todayMissionUseCase: todayMissionUseCase,
       checkCompletedTotalRecordsUseCase: checkCompletedTotalRecordsUseCase,
       checkRecordStatusUseCase: checkRecordStatusUseCase,
+      checkRecordCalendarUseCase: checkRecordCalendarUseCase,
+      removeGlobalCalendarRecordsUseCase: removeGlobalCalendarRecordsUseCase,
       startRecordUseCase: startRecordUseCase
     )
   }

--- a/WalWal/DependencyFactory/Mission/MissionDependencyFactory/Interface/MissionDependencyFactory.swift
+++ b/WalWal/DependencyFactory/Mission/MissionDependencyFactory/Interface/MissionDependencyFactory.swift
@@ -36,6 +36,8 @@ public protocol MissionDependencyFactory {
     todayMissionUseCase: TodayMissionUseCase,
     checkCompletedTotalRecordsUseCase: CheckCompletedTotalRecordsUseCase,
     checkRecordStatusUseCase: CheckRecordStatusUseCase,
+    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
+    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     startRecordUseCase: StartRecordUseCase
   ) -> any MissionReactor
   func injectMissionViewController<T: MissionReactor>(reactor: T) -> any MissionViewController

--- a/WalWal/DependencyFactory/Splash/SplashDependencyFactory/Implement/SplashDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/Splash/SplashDependencyFactory/Implement/SplashDependencyFactoryImp.swift
@@ -87,8 +87,6 @@ public class SplashDependencyFactoryImp: SplashDependencyFactory {
     checkTokenUseCase: CheckTokenUsecase,
     checkIsFirstLoadedUseCase: CheckIsFirstLoadedUseCase,
     fcmSaveUseCase: FCMSaveUseCase,
-    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
-    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     memberInfoUseCase: MemberInfoUseCase
   ) -> any SplashReactor {
     return SplashReactorImp(
@@ -96,8 +94,6 @@ public class SplashDependencyFactoryImp: SplashDependencyFactory {
       checkTokenUseCase: checkTokenUseCase,
       checkIsFirstLoadedUseCase: checkIsFirstLoadedUseCase,
       fcmSaveUseCase: fcmSaveUseCase,
-      checkRecordCalendarUseCase: checkRecordCalendarUseCase,
-      removeGlobalCalendarRecordsUseCase: removeGlobalCalendarRecordsUseCase,
       memberInfoUseCase: memberInfoUseCase
     )
   }

--- a/WalWal/DependencyFactory/Splash/SplashDependencyFactory/Interface/SplashDependencyFactory.swift
+++ b/WalWal/DependencyFactory/Splash/SplashDependencyFactory/Interface/SplashDependencyFactory.swift
@@ -56,8 +56,6 @@ public protocol SplashDependencyFactory {
     checkTokenUseCase: CheckTokenUsecase,
     checkIsFirstLoadedUseCase: CheckIsFirstLoadedUseCase,
     fcmSaveUseCase: FCMSaveUseCase,
-    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
-    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     memberInfoUseCase: MemberInfoUseCase
   ) -> any SplashReactor
   

--- a/WalWal/Features/Auth/AuthPresenter/Interface/Reactors/AuthReactor.swift
+++ b/WalWal/Features/Auth/AuthPresenter/Interface/Reactors/AuthReactor.swift
@@ -45,8 +45,6 @@ public protocol AuthReactor:
     fcmSaveUseCase: FCMSaveUseCase,
     userTokensSaveUseCase: UserTokensSaveUseCase,
     kakaoLoginUseCase: KakaoLoginUseCase,
-    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
-    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     memberInfoUseCase: MemberInfoUseCase
   )
 }

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Reactors/MissionReactorImp.swift
@@ -25,10 +25,12 @@ public final class MissionReactorImp: MissionReactor {
   
   public let initialState: State
   public let coordinator: any MissionCoordinator
-  public let todayMissionUseCase: TodayMissionUseCase
-  public let checkCompletedTotalRecordsUseCase: CheckCompletedTotalRecordsUseCase
-  public let checkRecordStatusUseCase: CheckRecordStatusUseCase
-  public let startRecordUseCase: StartRecordUseCase
+  private let todayMissionUseCase: TodayMissionUseCase
+  private let checkCompletedTotalRecordsUseCase: CheckCompletedTotalRecordsUseCase
+  private let checkRecordStatusUseCase: CheckRecordStatusUseCase
+  private let checkRecordCalendarUseCase: CheckCalendarRecordsUseCase
+  private let removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase
+  private let startRecordUseCase: StartRecordUseCase
   
   private let disposeBag = DisposeBag()
   
@@ -37,12 +39,16 @@ public final class MissionReactorImp: MissionReactor {
     todayMissionUseCase: TodayMissionUseCase,
     checkCompletedTotalRecordsUseCase: CheckCompletedTotalRecordsUseCase,
     checkRecordStatusUseCase: CheckRecordStatusUseCase,
+    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
+    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     startRecordUseCase: StartRecordUseCase
   ) {
     self.coordinator = coordinator
     self.todayMissionUseCase = todayMissionUseCase
     self.checkCompletedTotalRecordsUseCase = checkCompletedTotalRecordsUseCase
     self.checkRecordStatusUseCase = checkRecordStatusUseCase
+    self.checkRecordCalendarUseCase = checkRecordCalendarUseCase
+    self.removeGlobalCalendarRecordsUseCase = removeGlobalCalendarRecordsUseCase
     self.startRecordUseCase = startRecordUseCase
     self.initialState = State()
   }
@@ -114,9 +120,10 @@ public final class MissionReactorImp: MissionReactor {
   }
   
   private func loadAllMissionData() -> Observable<Mutation> {
-    return fetchMissionData()
-      .withUnretained(self)
-      .flatMap { owner, mission -> Observable<Mutation> in
+    return checkRecordCalendar()
+      .flatMap { _ in self.fetchMissionData()}
+      .flatMap { [weak self] mission -> Observable<Mutation> in
+        guard let owner = self else { return .empty() }
         return Observable.concat([
           Observable.just(Mutation.fetchTodayMissionData(mission)),
           owner.fetchRecordStatus(missionId: mission.id),
@@ -161,6 +168,28 @@ public final class MissionReactorImp: MissionReactor {
       .map { $0.recordId }
   }
   
+  /// 캘린더 정보도 여기서 업뎃 치자
+  private func checkRecordCalendar() -> Observable<Void> {
+    /// 우선 저장되어 있는 GlobalRecords 지우고, 새로운 calendar fetch
+    return removeGlobalCalendarRecordsUseCase.execute()
+      .asObservable()
+      .withUnretained(self)
+      .flatMap { owner, _ in owner.fetchCalendarRecords(cursor: "2024-01-01", limit: 30) }
+  }
+  
+  /// records/calendar 호출
+  private func fetchCalendarRecords(cursor: String, limit: Int) -> Observable<Void> {
+    return checkRecordCalendarUseCase.execute(cursor: cursor, limit: limit)
+      .asObservable()
+      .flatMap { calendarModel -> Observable<Void> in
+        if let nextCursor = calendarModel.nextCursor.nextCursor {
+          return self.fetchCalendarRecords(cursor: nextCursor, limit: limit)
+        } else {
+          return .just(Void())
+        }
+      }
+      .catch { error in return .just(Void()) }
+  }
   
   // MARK: - MissionTimer
   

--- a/WalWal/Features/Mission/MissionPresenter/Interface/Reactors/MissionReactor.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Interface/Reactors/MissionReactor.swift
@@ -58,9 +58,11 @@ public protocol MissionReactor: Reactor where Action == MissionReactorAction, Mu
   
   init(
     coordinator: any MissionCoordinator,
-    todayMissionUseCase: any TodayMissionUseCase,
-    checkCompletedTotalRecordsUseCase: any CheckCompletedTotalRecordsUseCase,
-    checkRecordStatusUseCase: any CheckRecordStatusUseCase,
-    startRecordUseCase: any StartRecordUseCase
-  ) 
+    todayMissionUseCase: TodayMissionUseCase,
+    checkCompletedTotalRecordsUseCase: CheckCompletedTotalRecordsUseCase,
+    checkRecordStatusUseCase: CheckRecordStatusUseCase,
+    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
+    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
+    startRecordUseCase: StartRecordUseCase
+  )
 }

--- a/WalWal/Features/Splash/SplashPresenter/Interface/Reactors/SplashReactor.swift
+++ b/WalWal/Features/Splash/SplashPresenter/Interface/Reactors/SplashReactor.swift
@@ -40,8 +40,6 @@ public protocol SplashReactor:
     checkTokenUseCase: CheckTokenUsecase,
     checkIsFirstLoadedUseCase: CheckIsFirstLoadedUseCase,
     fcmSaveUseCase: FCMSaveUseCase,
-    checkRecordCalendarUseCase: CheckCalendarRecordsUseCase,
-    removeGlobalCalendarRecordsUseCase: RemoveGlobalCalendarRecordsUseCase,
     memberInfoUseCase: MemberInfoUseCase
   )
 }


### PR DESCRIPTION
## 📌 개요
미션수행완료 후 기록을 GlobalState에 저장하는 로직을 추가하기 위해서, mission의 `loadInitialData` 액션에 대한 mutate로
캘린더 기록을 불러오는 로직을 추가했습니다.
또한, 이로인해 기존에 Splash에 존재하던 캘린더 기록을 호출하는 로직을 제거했습니다.
## ✍️ 변경사항

## 📷 스크린샷

## 🛠️ **Technical Concerns(기술적 고민)**
이렇게 수정한 결과, 캘린더 기록 불러오기 이후에 미션 데이터를 불러오는 과정을 수행하게 되어서
캘린더 기록이 많아질 경우 (cursor가 여러번 호출되는 경우) 해당 기간동안 미션이미지가 defualt이미지가 계속 노출되어있음....
다시 생각해도 default이미지에대한 고려를 해야할 것 같음.