### PR TITLE
미션시작하기 버튼 중복 입력 개선

### DIFF
--- a/WalWal/DesignSystem/Sources/Extensions/UIView+.swift
+++ b/WalWal/DesignSystem/Sources/Extensions/UIView+.swift
@@ -19,7 +19,7 @@ extension Reactive where Base: UIView {
     let event: Observable<Void> = base.rx.tapGesture()
       .when(.recognized)
       .throttle(
-        .milliseconds(400),
+        .milliseconds(1000),
         latest: false,
         scheduler: MainScheduler.instance
       )


### PR DESCRIPTION
## 📌 개요
커스텀버튼의 tapped에 걸려있는 throttle을 `400ms` -> `1000ms`로 증가 시켰습니다.
## ✍️ 변경사항
전체적인 버튼의 tapped의 throttle이 `1000ms`로 변경됨
## 📷 스크린샷

## 🛠️ **Technical Concerns(기술적 고민)**
