### PR TITLE
회원가입 시 키체인 토큰값 오류 해결

### DIFF
--- a/WalWal/Features/Auth/AuthDomain/Implement/Usecase/UserTokensSaveUseCaseImp.swift
+++ b/WalWal/Features/Auth/AuthDomain/Implement/Usecase/UserTokensSaveUseCaseImp.swift
@@ -17,6 +17,9 @@ public class UserTokensSaveUseCaseImp: UserTokensSaveUseCase {
   public func execute(tokens: AuthToken) {
     if tokens.isTemporaryToken {
       UserDefaults.setValue(value: tokens.accessToken, forUserDefaultKey: .temporaryToken)
+      if KeychainWrapper.shared.accessToken != nil {
+        let _ = KeychainWrapper.shared.setAccessToken(nil)
+      }
     } else {
       UserDefaults.setValue(value: tokens.refreshToken, forUserDefaultKey: .refreshToken)
       let _ = KeychainWrapper.shared.setAccessToken(tokens.accessToken)


### PR DESCRIPTION
## 📌 개요
회원가입 시 회원 정보를 찾을 수 없다는 오류를 해결하였습니다.

## ✍️ 변경사항
키체인에 토큰 값이 비워지지 않은 채 회원가입에서 닉네임 체크 api를 요청하게 되면 임시 토큰이 아닌 키체인에 남아있는 AccessToken값을 사용하는 것을 발견하였습니다.
아마도 작업하면서 강제적으로 로그인 화면으로 넘어가게 되거나 하는 특이 케이스인 것 같다는 생각..
이미 로그아웃이나 탈퇴에서 삭제를 수행하고는 있지만 추가적으로 로그인 시 임시 토큰값이 발급되는 경우에 키체인에 남아있는 토큰 값이 있다면 삭제하도록 로직을 추가하였습니다.

## 📷 스크린샷

## 🛠️ **Technical Concerns(기술적 고민)**
