### PR TITLE
미션 진행 중 뒤로가기 플로우 수정

### DIFF
--- a/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Reactors/CameraShootDuringTheMissionReactorImp.swift
+++ b/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Reactors/CameraShootDuringTheMissionReactorImp.swift
@@ -53,7 +53,7 @@ public final class CameraShootDuringTheMissionReactorImp: CameraShootDuringTheMi
     case .setLoading(let isLoading):
       newState.isLoading = isLoading
     case .moveToMain:
-      passFlagAndMoveToMission()
+      backToMission()
     }
     return newState
   }
@@ -61,11 +61,11 @@ public final class CameraShootDuringTheMissionReactorImp: CameraShootDuringTheMi
 
 // MARK: - Private Method
 extension CameraShootDuringTheMissionReactorImp {
-  private func passFlagAndMoveToMission() {
+  private func backToMission() {
     guard let tabBarViewController = coordinator.navigationController.tabBarController as? WalWalTabBarViewController else {
       return
     }
     tabBarViewController.showCustomTabBar()
-    coordinator.fetchMissionData()
+    coordinator.requirefinish()
   }
 }


### PR DESCRIPTION
## 📌 개요
기존에는 미션 진행 도중 뒤로가기를 했을 때 Mission의 데이터를 새로 Fetch하는 로직이 들어있었습니다.
이 로직을 제거해서, 불필요한 네트워크 통신을 방지합니다
## ✍️ 변경사항

## 📷 스크린샷

## 🛠️ **Technical Concerns(기술적 고민)**
