### PR TITLE
카메라 촬영 시 버튼 중복 tapped

### DIFF
--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
@@ -118,7 +118,15 @@ extension TabBarItemView {
 
 extension Reactive where Base: TabBarItemView {
   var tapped: ControlEvent<Void> {
-    ControlEvent(events: base.rx.tapGesture().when(.recognized).map { _ in })
+    let event: Observable<Void> = base.rx.tapGesture()
+      .when(.recognized)
+      .throttle(
+        .milliseconds(300),
+        latest: false,
+        scheduler: MainScheduler.instance
+      )
+      .map{ _ in }
+    return ControlEvent(events: event)
   }
   
   var isSelected: Binder<Bool> {

--- a/WalWal/DesignSystem/Sources/WalWalTouchArea/WalWalTouchArea.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTouchArea/WalWalTouchArea.swift
@@ -119,11 +119,3 @@ private extension WalWalTouchArea {
       .disposed(by: disposeBag)
   }
 }
-
-// MARK: - Reactive Extension
-
-public extension Reactive where Base: WalWalTouchArea {
-  var tapped: ControlEvent<Void> {
-    ControlEvent(events: base.rx.tapGesture().when(.recognized).map { _ in })
-  }
-}


### PR DESCRIPTION
## 📌 개요
WalWalTouchArea에 따로 `tapped`가 선언되어있어서, throttle이 걸려있는 UIView+의 `tapped`가 걸리지 않는 문제였습니다~
WalWalTouchArea에는 `tapped` extention 지웠어용
## ✍️ 변경사항

## 📷 스크린샷

## 🛠️ **Technical Concerns(기술적 고민)**
