### PR TITLE
부스트 동작하는 동안 외부 인터렉션 모두 막기

### DIFF
--- a/WalWal/DesignSystem/Sources/WalWalFeed/BoostAnimations/WalWalBoostGenerator.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/BoostAnimations/WalWalBoostGenerator.swift
@@ -26,6 +26,7 @@ final class WalWalBoostGenerator {
   
   private weak var feed: WalWalFeed?
   private var currentDetailView: UIView?
+  private var currentBackgroundView: UIView?
   private var currentBlackOverlayView: UIView?
   private var currentIndexPath: IndexPath?
   
@@ -73,10 +74,12 @@ final class WalWalBoostGenerator {
     }
     
     let detailView = createAndConfigureDetailView(from: cell, with: feedModel)
+    let backgroundView = createBackgroundView(frame: window.frame)
     let overlayView = createOverlayView(frame: detailView.frame)
     
     addViewsToWindow(
       detailView: detailView,
+      backgroundView: backgroundView,
       overlayView: overlayView,
       window: window
     )
@@ -87,20 +90,24 @@ final class WalWalBoostGenerator {
     )
     
     currentDetailView = detailView
+    currentBackgroundView = backgroundView
     currentBlackOverlayView = overlayView
   }
   
   /// 부스트 애니메이션 종료
   func stopBoostAnimation() {
     guard let detailView = currentDetailView,
+          let backgroundView = currentBackgroundView,
           let overlayView = currentBlackOverlayView,
           let indexPath = currentIndexPath else { return }
     
     UIView.animate(withDuration: 0.3, animations: {
       detailView.alpha = 0
+      backgroundView.alpha = 0
       overlayView.alpha = 0
     }) { _ in
       detailView.removeFromSuperview()
+      backgroundView.removeFromSuperview()
       overlayView.removeFromSuperview()
     }
     
@@ -108,6 +115,7 @@ final class WalWalBoostGenerator {
     walwalBoostCounter.stopCountTimer()
     walwalBoostBorder.stopBorderAnimation()
     currentDetailView = nil
+    currentBackgroundView = nil
     currentBlackOverlayView = nil
     walwalEmitter.stopEmitting()
     walwalEmitter.removeFromSuperlayer()
@@ -150,8 +158,8 @@ extension WalWalBoostGenerator {
   
   private func createBackgroundView(frame: CGRect) -> UIView {
     let backgroundView = UIView(frame: frame)
-    backgroundView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-    backgroundView.alpha = 0
+    backgroundView.backgroundColor = .clear
+    backgroundView.alpha = 1
     return backgroundView
   }
   
@@ -163,10 +171,12 @@ extension WalWalBoostGenerator {
   
   private func addViewsToWindow(
     detailView: UIView,
+    backgroundView: UIView,
     overlayView: UIView,
     window: UIWindow
   ) {
     window.addSubview(overlayView)
+    window.addSubview(backgroundView)
     window.addSubview(detailView)
   }
   


### PR DESCRIPTION
## 📌 개요
기존에 부스트 뒤의 dim처리되는 화면이 사라지면서, `backgroundView`로 만든 `View` 자체를 지웠는데
이렇게 했을 때, 부스트를 동작하는 동안 하단의 탭바가 선택되는 현상이 발생하게됩니다.

따라서 `backgroundView`는 살려두되, 색상을 `.clear`로 지정하여 시각적으로 보이지 않게 만들었습니다
## ✍️ 변경사항

## 📷 스크린샷

## 🛠️ **Technical Concerns(기술적 고민)**
