### PR TITLE
캘린더 클릭 시 해당 기록으로 이동

### DIFF
--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
@@ -70,10 +70,11 @@ public final class MyPageCoordinatorImp: MyPageCoordinator {
     destination
       .subscribe(with: self, onNext: { owner, flow in
         switch flow {
-        case .showRecordDetail(let nickname, let memberId):
+        case let .showRecordDetail(nickname, memberId, recordId):
           owner.showRecordDetailVC(
             nickname: nickname,
-            memberId: memberId
+            memberId: memberId,
+            recordId: recordId
           )
         case let .showProfileEdit(nickname, defaultProfile, selectImage, raisePet):
           owner.showProfileEditVC(
@@ -157,7 +158,8 @@ extension MyPageCoordinatorImp {
   /// 기록 상세뷰
   fileprivate func showRecordDetailVC(
     nickname: String,
-    memberId: Int
+    memberId: Int,
+    recordId: Int
   ) {
     let fetchUserFeedUseCase = feedDependencyFactory.injectFetchUserFeedUseCase()
     let reactor = myPageDependencyFactory.injectRecordDetailReactor(
@@ -166,7 +168,8 @@ extension MyPageCoordinatorImp {
     let recordDetailVC = myPageDependencyFactory.injectRecordDetailViewController(
       reactor: reactor,
       memberId: memberId,
-      memberNickname: nickname
+      memberNickname: nickname,
+      recordId: recordId
     )
     guard let tabBarViewController = navigationController.tabBarController as? WalWalTabBarViewController else {
       return

--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Interface/MyPageCoordinator.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Interface/MyPageCoordinator.swift
@@ -14,7 +14,11 @@ public enum MyPageCoordinatorAction: ParentAction {
 }
 
 public enum MyPageCoordinatorFlow: CoordinatorFlow {
-  case showRecordDetail(nickname: String, memberId: Int)
+  case showRecordDetail(
+    nickname: String,
+    memberId: Int,
+    recordId: Int
+  )
   case showProfileEdit(
     nickname: String,
     defaultProfile: String?,

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
@@ -94,12 +94,14 @@ public class MyPageDependencyFactoryImp: MyPageDependencyFactory {
   public func injectRecordDetailViewController<T: RecordDetailReactor>(
     reactor: T,
     memberId: Int,
-    memberNickname: String
+    memberNickname: String,
+    recordId: Int
   ) -> any RecordDetailViewController {
     return RecordDetailViewControllerImp(
       reactor: reactor,
       nickname: memberNickname,
       memberId: memberId,
+      recordId: recordId,
       isFeedRecord: false
     )
   }

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
@@ -63,7 +63,8 @@ public protocol MyPageDependencyFactory {
   func injectRecordDetailViewController<T: RecordDetailReactor>(
     reactor: T,
     memberId: Int,
-    memberNickname: String
+    memberNickname: String,
+    recordId: Int
   ) -> any RecordDetailViewController
   
   // MARK: - ProfileEdit

--- a/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
@@ -226,7 +226,7 @@ public final class WalWalFeed: UIView {
     }
     
     let indexPath = IndexPath(item: index, section: 0)
-    collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: animated)
+    collectionView.scrollToItem(at: indexPath, at: .top, animated: animated)
   }
   
   

--- a/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
@@ -218,6 +218,18 @@ public final class WalWalFeed: UIView {
     }
   }
   
+  /// 특정 레코드로 이동하는 메서드
+  public func scrollToRecord(withId recordId: Int, animated: Bool = true) {
+    guard let index = currentFeedData.firstIndex(where: { $0.recordId == recordId }) else {
+      print("기록 ID(\(recordId))에 해당하는 셀을 찾을 수 없습니다.")
+      return
+    }
+    
+    let indexPath = IndexPath(item: index, section: 0)
+    collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: animated)
+  }
+  
+  
   // MARK: - Boost Count Update
   
   private func updateBoostCount(for gesture: UILongPressGestureRecognizer) {

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/MyPageReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/MyPageReactorImp.swift
@@ -49,8 +49,8 @@ public final class MyPageReactorImp: MyPageReactor {
   
   public func mutate(action: Action) -> Observable<Mutation> {
     switch action {
-    case .didSelectCalendarItem(let member, let date):
-      return Observable.just(.moveToRecordDetail(memberInfo: member, cursor: date))
+    case .didSelectCalendarItem(let member, let calendar):
+      return Observable.just(.moveToRecordDetail(memberInfo: member, calendar: calendar))
     case .didTapSettingButton:
       return Observable.just(.moveToSettingView)
     case .didTapEditButton:
@@ -93,10 +93,11 @@ public final class MyPageReactorImp: MyPageReactor {
       ))
     case let .profileInfo(data):
       newState.profileData = data
-    case .moveToRecordDetail(let member, let cursor):
+    case .moveToRecordDetail(let member, let calendar):
       coordinator.destination.accept(.showRecordDetail(
         nickname: member.nickname,
-        memberId: member.memberId
+        memberId: member.memberId,
+        recordId: calendar.recordId
       ))
     }
     return newState

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/RecordDetailReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/RecordDetailReactorImp.swift
@@ -54,7 +54,7 @@ public final class RecordDetailReactorImp: RecordDetailReactor {
       if currentState.feedFetchEnded {
         return .empty()
       }
-      return fetchFeedData(memberId: memberId, cursor: cursorDate, limit: 10)
+      return fetchFeedData(memberId: memberId, cursor: cursorDate, limit: 30)
     case .tapBackButton:
       return .just(Mutation.moveToBack)
     }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/MyPageViewImp.swift
@@ -140,7 +140,10 @@ extension MyPageViewControllerImp: View {
   public func bindAction(reactor: R) {
     calendar.selectedDayData
       .map {
-        return Reactor.Action.didSelectCalendarItem(memberInfo: self.memberInfo, date: $0.date)
+        Reactor.Action.didSelectCalendarItem(
+          memberInfo: self.memberInfo,
+          calendar: $0
+        )
       }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
@@ -167,7 +170,8 @@ extension MyPageViewControllerImp: View {
   }
   
   public func bindState(reactor: R) {
-    reactor.state.map { $0.calendarData }
+    reactor.state
+      .map { $0.calendarData }
       .distinctUntilChanged()
       .bind(to: calendar.rx.updateModels)
       .disposed(by: disposeBag)

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/RecordDetailViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/RecordDetailViewImp.swift
@@ -45,6 +45,7 @@ public final class RecordDetailViewControllerImp<R: RecordDetailReactor>: UIView
   
   private var memberId: Int
   private var nickname: String
+  private var recordId: Int
   
   public var disposeBag = DisposeBag()
   public var recordDetailReactor: R
@@ -55,10 +56,12 @@ public final class RecordDetailViewControllerImp<R: RecordDetailReactor>: UIView
     reactor: R,
     nickname: String,
     memberId: Int,
+    recordId: Int,
     isFeedRecord: Bool
   ) {
     self.nickname = nickname
     self.memberId = memberId
+    self.recordId = recordId
     
     self.recordDetailReactor = reactor
     self.feed = WalWalFeed(feedData: dummyData, isFeed: false)
@@ -154,6 +157,8 @@ extension RecordDetailViewControllerImp: View {
       .observe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, feed in
         owner.feed.feedData.accept(feed)
+        
+        owner.feed.scrollToRecord(withId: owner.recordId, animated: true)
       })
       .disposed(by: disposeBag)
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/MyPageReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/MyPageReactor.swift
@@ -16,7 +16,7 @@ import ReactorKit
 import RxSwift
 
 public enum MyPageReactorAction {
-  case didSelectCalendarItem(memberInfo: MemberModel, date: String)
+  case didSelectCalendarItem(memberInfo: MemberModel, calendar: WalWalCalendarModel)
   case didTapSettingButton
   case didTapEditButton
   case loadCalendarData
@@ -27,7 +27,7 @@ public enum MyPageReactorMutation {
   case setSelectedCalendarItem(WalWalCalendarModel)
   case setCalendarData([WalWalCalendarModel]) // 캘린더 데이터를 설정하는 뮤테이션 추가
   case moveToSettingView
-  case moveToRecordDetail(memberInfo: MemberModel, cursor: String?)
+  case moveToRecordDetail(memberInfo: MemberModel, calendar: WalWalCalendarModel)
   case moveToEditView(data: MemberModel)
   case profileInfo(data: MemberModel)
 }


### PR DESCRIPTION
## 📌 개요
- issue: #227 
마이페이지 캘린더에서 해당 날짜 기록으로 이동하는 로직 구현했습니다.

## ✍️ 변경사항
- 캘린더 기록 데이터 limit 10개에서 30개로 변경했습니다. 
- 애니메이션을 넣으면 좀 빠르게 내려가는 것 같은데 아예 없으면 조금 어색해서 일단 있게 뒀습니다!

## 📷 스크린샷
![Simulator Screen Recording - iPhone 13 mini - 2024-08-28 at 13 06 38](https://github.com/user-attachments/assets/30124448-d991-4e70-9e0c-391b943c9939)

## 🛠️ **Technical Concerns(기술적 고민)**
