### PR TITLE
데이터 로드 시 스플래시 이미지 비율 오류 수정

### DIFF
--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -35,7 +35,9 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
   private let buttonContainerWrapper = UIView()
   private let bubbleContainerWrapper = UIView()
   
-  private let splashContainer = UIView()
+  private let splashContainer = UIView().then {
+    $0.backgroundColor = Colors.walwalOrange.color
+  }
   private let splashForLoading = UIImageView().then {
     $0.image = Images.splash.image
     $0.contentMode = .scaleAspectFit


### PR DESCRIPTION
## 📌 개요
iPhone 8에서 데이터 로드 시 보여지는 스플래시 이미지의 비율이 맞지 않는 문제 수정

## ✍️ 변경사항
- splashContainer의 배경 색을 스플래시 이미지 배경색과 동일하게 설정
- 
## 📷 스크린샷
### 수정 전
https://github.com/user-attachments/assets/c0b72e2e-aa33-4dea-862e-9f75725b977a

### 수정 후
https://github.com/user-attachments/assets/4ec16577-6197-499b-a0e1-cb42b4babbad


## 🛠️ **Technical Concerns(기술적 고민)**
