### PR TITLE
온보딩 및 프로필 수정 이미지 미설정 토스트 추가

### DIFF
--- a/WalWal/DesignSystem/Sources/WalWalToast/WalWalToast.swift
+++ b/WalWal/DesignSystem/Sources/WalWalToast/WalWalToast.swift
@@ -27,7 +27,6 @@ public final class WalWalToast {
   private let fadeOutDutaion: TimeInterval = 0.5
   private let bottomMargin: CGFloat = 13
   private var keyboardHeight: CGFloat = 0
-  private let disposeBag = DisposeBag()
   
   // MARK: - UI
   

--- a/WalWal/DesignSystem/Sources/WalWalToast/WalWalToast.swift
+++ b/WalWal/DesignSystem/Sources/WalWalToast/WalWalToast.swift
@@ -26,6 +26,8 @@ public final class WalWalToast {
   private let maintenanceTime: TimeInterval = 1.5
   private let fadeOutDutaion: TimeInterval = 0.5
   private let bottomMargin: CGFloat = 13
+  private var keyboardHeight: CGFloat = 0
+  private let disposeBag = DisposeBag()
   
   // MARK: - UI
   
@@ -48,9 +50,6 @@ public final class WalWalToast {
   // MARK: - Layout
   
   private func configureLayout() {
-    guard let window = UIWindow.key else { return }
-    let safeAreaBottomInset = window.topViewControllerSafeAreaInsets?.bottom ?? 34
-    
     container.flex
       .direction(.row)
       .height(56)
@@ -63,14 +62,21 @@ public final class WalWalToast {
           .marginLeft(6)
           .grow(1)
       }
+    updateToastPosition()
+  }
+  
+  private func updateToastPosition() {
+    guard let window = UIWindow.key else { return }
+    let safeAreaBottomInset = window.topViewControllerSafeAreaInsets?.bottom ?? 34
+    let bottomOffset = safeAreaBottomInset + keyboardHeight + bottomMargin
     
     container.pin
       .horizontally(16)
-      .bottom(safeAreaBottomInset+bottomMargin)
+      .bottom(bottomOffset)
     container.flex
       .layout(mode: .adjustHeight)
     container.pin
-      .bottom(safeAreaBottomInset+bottomMargin-10)
+      .bottom(bottomOffset-10)
   }
   
   /// 토스트 메세지 띄우는 메서드
@@ -78,12 +84,14 @@ public final class WalWalToast {
   /// - Parameters:
   ///   - type: 토스트 메세지 타입(타입에 따라 아이콘이 달라짐)
   ///   - message: 토스트 메세지 내용, nil일 경우 ToastType에 지정된 기본 메세지 출력
+  ///   - keyboardHeight: 키보드 올라와있을 경우 키보드 위로 띄우기 위한 높이 파라미터
   public func show(
     type: ToastType,
-    message: String? = nil
+    message: String? = nil,
+    keyboardHeight: CGFloat = 0
   ) {
     guard let window = UIWindow.key else { return }
-    
+    self.keyboardHeight = keyboardHeight
     self.messageLabel.text = message ?? type.message
     self.iconImage.image = type.icon
     window.addSubview(container)
@@ -96,6 +104,7 @@ public final class WalWalToast {
   private func render() {
     guard let window = UIWindow.key else { return }
     let safeAreaBottomInset = window.topViewControllerSafeAreaInsets?.bottom ?? 34
+    let bottomOffset = safeAreaBottomInset + keyboardHeight + bottomMargin
     UIView.animate(
       withDuration: self.fadeInDuration,
       delay: 0,
@@ -106,7 +115,7 @@ public final class WalWalToast {
         }
         
         self.container.transform = CGAffineTransform(translationX: 0, y: -10)
-        self.container.pin.bottom(safeAreaBottomInset+bottomMargin)
+        self.container.pin.bottom(bottomOffset)
         container.alpha = 1.0
       },
       completion: { [weak self] _ in

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/ProfileEditReactorImp.swift
@@ -264,12 +264,9 @@ extension ProfileEditReactorImp {
        nickname == profileModel.nickname {
       
       return .just(.buttonEnable(isEnable: false))
-    }
-    
-    else if nickname.count < 2 {
+    } else if nickname.count < 2 {
       return .just(.buttonEnable(isEnable: false))
-    }
-    else if nickname.count > 14 {
+    } else if nickname.count > 14 {
       let errorMessage = ProfileEditError.maxLengthNickname.message
       return .concat([
         .just(.buttonEnable(isEnable: false)),
@@ -281,6 +278,8 @@ extension ProfileEditReactorImp {
         .just(.buttonEnable(isEnable: false)),
         .just(.invalidNickname(message: errorMessage))
       ])
+    } else if profile.profileType == .selectImage && profile.selectImage == nil {
+      return .just(.buttonEnable(isEnable: false))
     } else {
       return .just(.buttonEnable(isEnable: true))
     }

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/ProfileEditReactor.swift
@@ -31,7 +31,7 @@ public enum ProfileEditReactorMutation {
   case setPhotoPermission(Bool)
   case moveToBack
   case profileInfo(info: MemberModel)
-  
+  case errorMessage(message: String)
 }
 
 public struct ProfileEditReactorState {
@@ -41,6 +41,7 @@ public struct ProfileEditReactorState {
   @Pulse public var isGrantedPhoto: Bool = false
   @Pulse public var invalidMessage: String = ""
   public var profileInfo: MemberModel?
+  @Pulse public var errorToastMessage: String? = nil
 }
 
 

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingProfileViewImp.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Implement/Views/OnboardingProfileViewImp.swift
@@ -32,6 +32,13 @@ public final class OnboardingProfileViewControllerImp<R: OnboardingProfileReacto
   
   public var disposeBag = DisposeBag()
   private var onboardingReactor: R
+  private let buttonEnable = BehaviorRelay<Bool>(value: false)
+  private let enableButtonStyle: WalWalButtonType = .custom(
+    backgroundColor: Color.gray300.color,
+    titleColor: Color.white.color,
+    font: Font.H6.B,
+    isEnable: true
+  )
   
   // MARK: - UI
   
@@ -63,7 +70,10 @@ public final class OnboardingProfileViewControllerImp<R: OnboardingProfileReacto
     placeholder: "닉네임을 입력해주세요",
     rightIcon: .close
   )
-  private let nextButton = WalWalButton(type: .disabled, title: "다음")
+  private lazy var nextButton = WalWalButton(
+    type: enableButtonStyle,
+    title: "다음"
+  )
   
   // MARK: - Initialize
   
@@ -252,7 +262,11 @@ extension OnboardingProfileViewControllerImp: View {
       .disposed(by: disposeBag)
     
     reactor.state
-      .map { return $0.buttonEnable ? .active : .disabled }
+      .map { $0.buttonEnable }
+      .map {
+        self.buttonEnable.accept($0)
+        return $0 ? .active : self.enableButtonStyle
+      }
       .bind(to: nextButton.rx.buttonType)
       .disposed(by: disposeBag)
     

--- a/WalWal/Features/Onboarding/OnboardingPresenter/Interface/Reactors/OnboardingProfileReactor.swift
+++ b/WalWal/Features/Onboarding/OnboardingPresenter/Interface/Reactors/OnboardingProfileReactor.swift
@@ -30,6 +30,7 @@ public enum OnboardingProfileReactorMutation {
   case showIndicator(show: Bool)
   case setPhotoPermission(isAllow: Bool)
   case moveToBack
+  case errorToastMessage(String)
 }
 
 public struct OnboardingProfileReactorState {


### PR DESCRIPTION
## 📌 개요
온보딩 또는 프로필 수정 뷰에서 프로필 이미지를 설정하지 않은 채로 다음버튼 탭 시 오류 토스트 발생하도록 수정

## ✍️ 변경사항
### WalWalToast 키보드 올라가있을 경우 margin bottom 수정
- 파라미터 값으로 키보드 높이 값을 전달하도록 수정
### 비활성화 버튼 수정
- 프로필 이미지 설정 뷰에서 비활성화 된 버튼을 눌렀을 경우 프로필 이미지 설정에 대한 토스트를 띄우기 위해 `.disabled`가 아닌 `.custom`으로 비활성화 조건의 경우에도 버튼 액션을 전달할 수 있도록 수정


## 📷 스크린샷
|온보딩|프로필 수정|
|:-----:|:-----:|
|<img src = "https://github.com/user-attachments/assets/976785f9-1c55-45a6-a850-eed01fdcc8b9" width="331">|<img src = "https://github.com/user-attachments/assets/81104ed2-d6fe-4d82-b2a3-adf5a24f360f" width = "331">


## 🛠️ **Technical Concerns(기술적 고민)**
토스트 bottom margin 값을 WalWalToast 내에서 키보드 올라온 것을 인지해서 조절하도록 하고싶었는데 방법을 못찾았습니다..
`NotificationCenter`를 이용해봤는데 키보드가 미리 올라와있는 채로 토스트를 최초로 호출하면 키보드가 올라온 것을 토스트 클래스에서는 인지하지 못하는 문제가 있습니다..!

그래서 현재는 토스트를 사용하려는 뷰에서 키보드 올라왔는지 여부를 체크해서 높이 값을 전달하도록 구현하였는데 
좋은 방법이 있다면 의견 주세용~