### PR TITLE
알림 리스트 없을 경우 엣지페이지 보여주기

### DIFF
--- a/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
@@ -79,6 +79,8 @@ public final class FCMReactorImp: FCMReactor {
       newState.nextCursor = cursor
     case let .isLastPage(isLast):
       newState.isLastPage = isLast
+    case let .isHiddenEdgePage(isHidden):
+      newState.isHiddenEdgePage = isHidden
     }
     return newState
   }
@@ -114,7 +116,10 @@ extension FCMReactorImp {
     return fetchFCMListUseCase.execute()
       .withUnretained(self)
       .flatMap { owner, data -> Observable<Mutation> in
-        return .just(.loadFCMList(data: owner.separateDataByDate(data: data)))
+        return .concat([
+          .just(.isHiddenEdgePage(!data.isEmpty)),
+          .just(.loadFCMList(data: owner.separateDataByDate(data: data)))
+        ])
       }
   }
   

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Views/Components/FCMEdgeView.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Views/Components/FCMEdgeView.swift
@@ -1,0 +1,88 @@
+//
+//  FCMEdgeView.swift
+//  FCMPresenterImp
+//
+//  Created by Jiyeon on 9/11/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import ResourceKit
+
+import FlexLayout
+import PinLayout
+import Then
+
+final class FCMEdgeView: UIView {
+  
+  private typealias Images = ResourceKitAsset.Images
+  private typealias Colors = ResourceKitAsset.Colors
+  private typealias Fonts = ResourceKitFontFamily
+  
+  
+  // MARK: - UI
+  
+  private let rootContainerView = UIView()
+  private let titleLabel = CustomLabel(
+    text: "앗..",
+    font: Fonts.LotteriaChab.Buster_Cute
+  ).then {
+    $0.textColor = Colors.black.color
+  }
+  private let subTitelLabel = CustomLabel(
+    text: "아직 알림이 없어요!",
+    font: Fonts.KR.H5.B
+  ).then {
+    $0.textColor = Colors.black.color
+  }
+  private let guideLabel = CustomLabel(
+    text: "조금만 기다리면 알림이 올 거예요",
+    font: Fonts.KR.H7.M
+  ).then {
+    $0.textAlignment = .center
+    $0.textColor = Colors.black.color
+  }
+  
+  // MARK: - Initialize
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configAttributes()
+    configLayout()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Layout
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    rootContainerView.pin
+      .all()
+    rootContainerView.flex
+      .layout(mode: .adjustHeight)
+  }
+  
+  private func configAttributes() {
+    addSubview(rootContainerView)
+  }
+  
+  private func configLayout() {
+    rootContainerView.flex
+      .justifyContent(.center)
+      .alignItems(.center)
+      .define {
+        $0.addItem(titleLabel)
+        $0.addItem(subTitelLabel)
+          .marginTop(6)
+        $0.addItem(guideLabel)
+          .marginTop(2)
+      }
+  }
+  
+  
+}

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
@@ -55,13 +55,14 @@ public final class FCMViewControllerImp<R: FCMReactor>:
     frame: .zero,
     collectionViewLayout: collectionViewLayout()
   ).then {
-    $0.backgroundColor = Colors.gray100.color
+    $0.backgroundColor = .clear
     $0.register(FCMCollectionViewCell.self)
     $0.registerHeader(FCMCollectionViewHeader.self)
     $0.showsVerticalScrollIndicator = false
     $0.delegate = self
     $0.refreshControl = walwalIndicator
   }
+  private let edgeView = FCMEdgeView()
   
   public init(
     reactor: R
@@ -109,10 +110,15 @@ public final class FCMViewControllerImp<R: FCMReactor>:
         $0.addItem(separator)
           .width(100%)
           .height(1)
-        $0.addItem(collectionView)
-          .marginTop(13.adjustedHeight)
+        $0.addItem(edgeView)
+          .marginTop(204.adjustedHeight)
           .width(100%)
           .grow(1)
+        $0.addItem(collectionView)
+          .position(.absolute)
+          .top(61 + 13.adjustedHeight)
+          .width(100%)
+          .bottom(0)
       }
   }
   
@@ -241,6 +247,16 @@ extension FCMViewControllerImp: View {
       .map { $0.nextCursor }
       .distinctUntilChanged()
       .bind(to: nextCursor)
+      .disposed(by: disposeBag)
+    
+    reactor.state
+      .map { $0.isHiddenEdgePage }
+      .distinctUntilChanged()
+      .debug()
+      .asDriver(onErrorJustReturn: false)
+      .drive(with: self) { owner, isHidden in
+        owner.edgeView.isHidden = isHidden
+      }
       .disposed(by: disposeBag)
   }
   

--- a/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
@@ -28,6 +28,7 @@ public enum FCMReactorMutation {
   case updateItem(index: IndexPath)
   case nextCursor(cursor: String?)
   case isLastPage(Bool)
+  case isHiddenEdgePage(Bool)
 }
 
 public struct FCMReactorState {
@@ -36,6 +37,7 @@ public struct FCMReactorState {
   @Pulse public var stopRefreshControl: Bool = false
   public var nextCursor: String? = nil
   public var isLastPage: Bool = false
+  public var isHiddenEdgePage: Bool = true
 }
 
 public protocol FCMReactor: Reactor where Action == FCMReactorAction, Mutation == FCMReactorMutation, State == FCMReactorState {


### PR DESCRIPTION
## 📌 개요
알림 리스트가 없을 경우 기존에 사용하던 엣지페이지를 보여주도록 수정하였습니다.

## ✍️ 변경사항
- 엣지페이지 뷰 구현
- 알림 리스트가 없을 경우 해당 페이지 보여주기

## 📷 스크린샷
<img src="https://github.com/user-attachments/assets/7f6a212a-6dc0-4cbb-937f-ab36d86d3d5b" width = "35%">


## 🛠️ **Technical Concerns(기술적 고민)**
