### PR TITLE
부스트 버그 수정

### DIFF
--- a/WalWal/DesignSystem/Sources/WalWalFeed/BoostAnimations/WalWalBoostCounter.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/BoostAnimations/WalWalBoostCounter.swift
@@ -20,6 +20,10 @@ final class WalWalBoostCounter {
   private var countLabel: UILabel?
   private var borderLabel: UILabel?
   
+  func resetCount(){
+    currentCount = 0
+  }
+  
   func setupCountLabel(in window: UIWindow, detailView: UIView) {
     currentCount = 0
     countLabel = UILabel()

--- a/WalWal/DesignSystem/Sources/WalWalFeed/BoostAnimations/WalWalBoostGenerator.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/BoostAnimations/WalWalBoostGenerator.swift
@@ -61,6 +61,7 @@ final class WalWalBoostGenerator {
     for gesture: UILongPressGestureRecognizer,
     in collectionView: UICollectionView
   ) {
+    walwalBoostCounter.resetCount()
     let point = gesture.location(in: collectionView)
     guard let indexPath = collectionView.indexPathForItem(at: point),
           let cell = collectionView.cellForItem(at: indexPath) as? WalWalFeedCell,

--- a/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
@@ -179,20 +179,23 @@ public final class WalWalFeed: UIView {
       .withUnretained(self) { (owner, boostResult) in
         var updatedFeedData = owner.feedData.value
         var boostCount = boostResult.count
-        if let feedModel = updatedFeedData[safe: boostResult.indexPath.item] {
-          if boostResult.count > 500 {
-            WalWalToast.shared.show(type: .boost, message: "부스터는 최대 500개까지만 가능해요!")
-            boostCount = 500
+        
+        if boostCount > 0 {
+          if let feedModel = updatedFeedData[safe: boostResult.indexPath.item] {
+            if boostResult.count > 500 {
+              WalWalToast.shared.show(type: .boost, message: "부스터는 최대 500개까지만 가능해요!")
+              boostCount = 500
+            }
+            
+            var updatedModel = feedModel
+            updatedModel.boostCount += boostCount
+            updatedFeedData[boostResult.indexPath.item] = updatedModel
+            
+            owner.updatedBoost.accept(
+              (recordId: updatedModel.recordId,
+               count: boostCount)
+            )
           }
-          
-          var updatedModel = feedModel
-          updatedModel.boostCount += boostCount
-          updatedFeedData[boostResult.indexPath.item] = updatedModel
-          
-          owner.updatedBoost.accept(
-            (recordId: updatedModel.recordId,
-             count: boostCount)
-          )
         }
         
         return updatedFeedData
@@ -241,7 +244,6 @@ public final class WalWalFeed: UIView {
     updatedRecord = feedModel
     collectionView.collectionViewLayout.invalidateLayout()
     feedData.accept(updatedFeedData)
-    
   }
   
   // MARK: - Scroll


### PR DESCRIPTION
## 📌 개요
- issue: #262 

## ✍️ 변경사항
1. 부스트 타이머 시작 전 0.25초 (딤처리 + 뷰 확대) 동안의 지연이 있는데, 이 시기에 탭 제스처를 끝내면 이전 값이 그대로 보내지는 오류가 존재했습니다. 부스트 애니메이션 시작 시 count를 초기화 시키는 로직을 추가하여 수정했습니다. 
2. 부스트 개수가 0이어도 불필요한 서버 통신이 되어 부스트 개수가 0 이상일 때만 서버 통신하도록 수정했습니다.

## 📷 스크린샷
![RPReplay_Final1726840418](https://github.com/user-attachments/assets/849c2e96-5d4f-47a0-bb9e-1b5c765a953f)

## 🛠️ **Technical Concerns(기술적 고민)**
