### PR TITLE
앱스토어 리뷰 팝업 구현

### DIFF
--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -204,6 +204,7 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
       self.missionCompletedView.configureStartView(recordImageURL: status.imageUrl)
       self.missionStartView.isHidden = true
       self.missionCompletedView.isHidden = false
+      requestStoreReview()
     case .notCompleted, .inProgress:
       self.missionStartView.isHidden = false
       self.missionCompletedView.isHidden = true
@@ -253,6 +254,11 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
       window?.addSubview(missionMarkView)
       missionMarkView.pin.all()
     }
+  }
+  
+  private func requestStoreReview() {
+    let missionCompletedCount = missionReactor.currentState.totalCompletedRecordsCount
+    StoreReviewManager.shared.requestReview(missionCount: missionCompletedCount)
   }
   
   // MARK: - Notification Setup

--- a/WalWal/Utility/Sources/StoreReviewManager.swift
+++ b/WalWal/Utility/Sources/StoreReviewManager.swift
@@ -1,0 +1,29 @@
+//
+//  StoreReviewManager.swift
+//  Utility
+//
+//  Created by Jiyeon on 9/25/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import Foundation
+import StoreKit
+
+public final class StoreReviewManager {
+  
+  public static let shared = StoreReviewManager()
+  private init() { }
+  
+  private let minimumReviewRequestCount = 5
+  
+  public func requestReview(missionCount: Int) {
+    guard missionCount > minimumReviewRequestCount else { return }
+    
+    guard let scene = UIApplication.shared.connectedScenes.first(where: {
+      $0.activationState == .foregroundActive
+    }) as? UIWindowScene else {
+      return
+    }
+    SKStoreReviewController.requestReview(in: scene)
+  }
+}

--- a/WalWal/Utility/Sources/StoreReviewManager.swift
+++ b/WalWal/Utility/Sources/StoreReviewManager.swift
@@ -17,7 +17,7 @@ public final class StoreReviewManager {
   private let minimumReviewRequestCount = 5
   
   public func requestReview(missionCount: Int) {
-    guard missionCount > minimumReviewRequestCount else { return }
+    guard missionCount >= minimumReviewRequestCount else { return }
     
     guard let scene = UIApplication.shared.connectedScenes.first(where: {
       $0.activationState == .foregroundActive


### PR DESCRIPTION
## 📌 개요
앱스토어 리뷰 요청 팝업 구현

## ✍️ 변경사항
- 미션 완료 시 미션 완료 뷰로 전환되었을 때 팝업이 뜨도록 구현
- 미션을 5회 이상 완료하였을 경우 팝업이 뜰 수 있도록 조건 설정

### 애플 정책
- 앱스토어 리뷰는 애플 정책 상 1년에 최대 3번까지 사용자에게 보여줄 수 있음
- `StoreKit`을 사용하여 시스템 팝업을 사용할 경우 팝업이 나타날지에 대한 여부는 애플 정책에 따라 애플이 결정하게 됨
- 때문에 조건을 5회 이상이라고 설정해두었지만 무조건 5회가 되었을 때 뜨는 것은 아님!
  - **디버그 모드**에서는 조건에 충족되면 무조건 뜸
  - **테플**에서는 팝업이 나타나지 않음
  - **릴리즈**에서는 **애플 정책**에 따름

## 📷 스크린샷
<img src = "https://github.com/user-attachments/assets/647aed61-f971-47d7-af51-a71d32302f1b" width = "35%">

## 🛠️ **Technical Concerns(기술적 고민)**
