### PR TITLE
feat: #273 더블 탭으로 최상단 이동 구현

### DIFF
--- a/WalWal/Coordinators/FCM/FCMCoordinator/Implement/FCMCoordinatorImp.swift
+++ b/WalWal/Coordinators/FCM/FCMCoordinator/Implement/FCMCoordinatorImp.swift
@@ -140,7 +140,6 @@ extension FCMCoordinatorImp {
   }
   
   public func doubleTap(index: Int) {
-    print("index:\(index)")
     doubleTapRelay.accept(index)
   }
 }

--- a/WalWal/Coordinators/FCM/FCMCoordinator/Implement/FCMCoordinatorImp.swift
+++ b/WalWal/Coordinators/FCM/FCMCoordinator/Implement/FCMCoordinatorImp.swift
@@ -27,6 +27,8 @@ public final class FCMCoordinatorImp: FCMCoordinator {
   public var childCoordinator: (any BaseCoordinator)?
   public var baseViewController: UIViewController?
   
+  public let doubleTapRelay = PublishRelay<Int>()
+  
   public var fcmDependencyFactory: FCMDependencyFactory
   
   public required init(
@@ -77,6 +79,13 @@ public final class FCMCoordinatorImp: FCMCoordinator {
       saveFCMListGlobalStateUseCase: saveFCMListGlobalStateUseCase
     )
     let fcmVC = fcmDependencyFactory.injectFCMViewController(reactor: reactor)
+    
+    doubleTapRelay
+      .subscribe(with: self, onNext: { owner, index in
+        reactor.action.onNext(.doubleTap(index))
+      })
+      .disposed(by: disposeBag)
+    
     self.baseViewController = fcmVC
     self.pushViewController(viewController: fcmVC, animated: false)
   }
@@ -128,5 +137,10 @@ extension FCMCoordinatorImp {
   }
   public func startFeed() {
     requireParentAction(.startFeed)
+  }
+  
+  public func doubleTap(index: Int) {
+    print("index:\(index)")
+    doubleTapRelay.accept(index)
   }
 }

--- a/WalWal/Coordinators/FCM/FCMCoordinator/Interface/FCMCoordinator.swift
+++ b/WalWal/Coordinators/FCM/FCMCoordinator/Interface/FCMCoordinator.swift
@@ -21,4 +21,5 @@ public enum FCMCoordinatorFlow: CoordinatorFlow {
 public protocol FCMCoordinator: BaseCoordinator {
   func startMission()
   func startFeed()
+  func doubleTap(index: Int)
 }

--- a/WalWal/Coordinators/Feed/FeedCoordinator/Interface/FeedCoordinator.swift
+++ b/WalWal/Coordinators/Feed/FeedCoordinator/Interface/FeedCoordinator.swift
@@ -17,6 +17,10 @@ public enum FeedCoordinatorFlow: CoordinatorFlow {
   
 }
 
-public protocol FeedCoordinator: BaseCoordinator where Flow == FeedCoordinatorFlow {
+public protocol FeedCoordinator: BaseCoordinator
+where Flow == FeedCoordinatorFlow,
+      Action == FeedCoordinatorAction
+{
   func startProfile(memberId: Int, nickName: String)
+  func doubleTap(index: Int)
 }

--- a/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
+++ b/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
@@ -107,12 +107,12 @@ public final class WalWalTabBarCoordinatorImp: WalWalTabBarCoordinator {
         
         if owner.lastSelectedIndex == idx {
           // 같은 탭을 두 번 눌렀을 때
-          switch idx {
-          case 1:
+          switch tabBarItem {
+          case .startFeed:
             if let feedCoordinator = owner.tabCoordinators[.startFeed] as? (any FeedCoordinator) {
               feedCoordinator.doubleTap(index: idx)
             }
-          case 2:
+          case .startNotification:
             if let notificationCoordinator = owner.tabCoordinators[.startNotification] as? (any FCMCoordinator) {
               notificationCoordinator.doubleTap(index: idx)
             }

--- a/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
+++ b/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
@@ -48,6 +48,7 @@ public final class WalWalTabBarCoordinatorImp: WalWalTabBarCoordinator {
   public var childCoordinator: (any BaseCoordinator)?
   public var baseViewController: UIViewController?
   private let forceMoveTab = PublishRelay<Flow>()
+  public private(set) var doubleTapRelay = PublishRelay<Int>()
   
   public var walwalTabBarDependencyFactory: WalWalTabBarDependencyFactory
   public var missionDependencyFactory: MissionDependencyFactory
@@ -103,6 +104,15 @@ public final class WalWalTabBarCoordinatorImp: WalWalTabBarCoordinator {
         let tabBarItem = Flow(rawValue: idx) ?? .startMission
         owner.destination.accept(tabBarItem)
       })
+      .disposed(by: disposeBag)
+    
+    self.tabBarController.doubleTapRelay
+      .subscribe(with: self) { owner, index in
+        // 현재 활성화된 FeedCoordinator를 확인하고 doubleTap 메서드 호출
+        if let feedCoordinator = owner.tabCoordinators[.startFeed] as? (any FeedCoordinator) {
+            feedCoordinator.doubleTap(index: index) // doubleTap 이벤트 전달
+        }
+      }
       .disposed(by: disposeBag)
     
     self.destination

--- a/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
+++ b/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
@@ -108,9 +108,17 @@ public final class WalWalTabBarCoordinatorImp: WalWalTabBarCoordinator {
     
     self.tabBarController.doubleTapRelay
       .subscribe(with: self) { owner, index in
-        // 현재 활성화된 FeedCoordinator를 확인하고 doubleTap 메서드 호출
-        if let feedCoordinator = owner.tabCoordinators[.startFeed] as? (any FeedCoordinator) {
-            feedCoordinator.doubleTap(index: index) // doubleTap 이벤트 전달
+        switch index {
+        case 1:
+          if let feedCoordinator = owner.tabCoordinators[.startFeed] as? (any FeedCoordinator) {
+            feedCoordinator.doubleTap(index: index)
+          }
+        case 2:
+          if let notificationCoordinator = owner.tabCoordinators[.startNotification] as? (any FCMCoordinator) {
+            notificationCoordinator.doubleTap(index: index)
+          }
+        default:
+          break
         }
       }
       .disposed(by: disposeBag)

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
@@ -136,14 +136,4 @@ extension Reactive where Base: TabBarItemView {
       view.selected(isSelected)
     }
   }
-  
-  var doubleTapped: ControlEvent<Void> {
-    let event: Observable<Void> = base.rx
-      .tapGesture { gesture, _ in
-          gesture.numberOfTapsRequired = 2
-      }
-      .when(.recognized)
-      .map { _ in }
-    return ControlEvent(events: event)
-  }
 }

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
@@ -143,9 +143,7 @@ extension Reactive where Base: TabBarItemView {
           gesture.numberOfTapsRequired = 2
       }
       .when(.recognized)
-    
       .map { _ in }
-    
     return ControlEvent(events: event)
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/TabBarItemView.swift
@@ -8,11 +8,13 @@
 
 import UIKit
 import ResourceKit
+
 import FlexLayout
 import PinLayout
 import Then
 import RxSwift
 import RxCocoa
+import RxGesture
 
 class TabBarItemView: UIView {
   
@@ -107,7 +109,7 @@ extension TabBarItemView {
   }
   
   private func updateAppearance(isSelected: Bool) {
-    iconImageView.image = isSelected 
+    iconImageView.image = isSelected
     ? item.selectedIcon
     : item.icon
     titleLabel.textColor = isSelected
@@ -133,5 +135,17 @@ extension Reactive where Base: TabBarItemView {
     return Binder(base) { view, isSelected in
       view.selected(isSelected)
     }
+  }
+  
+  var doubleTapped: ControlEvent<Void> {
+    let event: Observable<Void> = base.rx
+      .tapGesture { gesture, _ in
+          gesture.numberOfTapsRequired = 2
+      }
+      .when(.recognized)
+    
+      .map { _ in }
+    
+    return ControlEvent(events: event)
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/WalWalTabBarView.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/WalWalTabBarView.swift
@@ -41,6 +41,11 @@ final class WalWalTabBarView: UIView {
   
   let selectedIndex = BehaviorRelay<Int>(value: 0)
   let moveIndex = PublishRelay<Int>()
+  private let doubleTapRelay = PublishRelay<Int>()
+  
+  var doubleTapEvent: Observable<Int> {
+    return doubleTapRelay.asObservable()
+  }
   
   private let disposeBag = DisposeBag()
   
@@ -108,6 +113,14 @@ extension WalWalTabBarView {
     )
     .bind(to: selectedIndex)
     .disposed(by: disposeBag)
+    
+    tabBarItems.enumerated().forEach { index, item in
+      item.rx.doubleTapped
+        .subscribe(onNext: { [weak self] in
+          self?.doubleTapRelay.accept(index)
+        })
+        .disposed(by: disposeBag)
+    }
     
     selectedIndex
       .subscribe(with: self, onNext: { owner, index in

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/WalWalTabBarView.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/Component/WalWalTabBarView.swift
@@ -41,11 +41,6 @@ final class WalWalTabBarView: UIView {
   
   let selectedIndex = BehaviorRelay<Int>(value: 0)
   let moveIndex = PublishRelay<Int>()
-  private let doubleTapRelay = PublishRelay<Int>()
-  
-  var doubleTapEvent: Observable<Int> {
-    return doubleTapRelay.asObservable()
-  }
   
   private let disposeBag = DisposeBag()
   
@@ -113,14 +108,6 @@ extension WalWalTabBarView {
     )
     .bind(to: selectedIndex)
     .disposed(by: disposeBag)
-    
-    tabBarItems.enumerated().forEach { index, item in
-      item.rx.doubleTapped
-        .subscribe(onNext: { [weak self] in
-          self?.doubleTapRelay.accept(index)
-        })
-        .disposed(by: disposeBag)
-    }
     
     selectedIndex
       .subscribe(with: self, onNext: { owner, index in

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
@@ -32,8 +32,6 @@ public final class WalWalTabBarViewController: UITabBarController {
   // MARK: - Properties
   
   public private(set) var selectedFlow = PublishRelay<Int>()
-  public private(set) var doubleTapRelay = PublishRelay<Int>()
-  
   
   public let forceMoveTab = PublishRelay<Int>()
   
@@ -99,7 +97,6 @@ extension WalWalTabBarViewController {
   
   private func bind() {
     customTabBar.selectedIndex
-      .distinctUntilChanged()
       .subscribe(with: self, onNext: { owner, index in
         owner.selectedFlow.accept(index)
       })
@@ -107,12 +104,6 @@ extension WalWalTabBarViewController {
     
     forceMoveTab
       .bind(to: customTabBar.moveIndex)
-      .disposed(by: disposeBag)
-    
-    customTabBar.doubleTapEvent
-      .subscribe(with: self, onNext: { owner, index in
-        owner.doubleTapRelay.accept(index)
-      })
       .disposed(by: disposeBag)
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
@@ -32,6 +32,9 @@ public final class WalWalTabBarViewController: UITabBarController {
   // MARK: - Properties
   
   public private(set) var selectedFlow = PublishRelay<Int>()
+  public private(set) var doubleTapRelay = PublishRelay<Int>()
+  
+  
   public let forceMoveTab = PublishRelay<Int>()
   
   private let disposeBag = DisposeBag()
@@ -63,7 +66,7 @@ public final class WalWalTabBarViewController: UITabBarController {
   }
   
   // MARK: - Methods
-
+  
   public func hideCustomTabBar() {
     self.tabBar.isHidden = true
     containerView.isHidden = true
@@ -104,6 +107,12 @@ extension WalWalTabBarViewController {
     
     forceMoveTab
       .bind(to: customTabBar.moveIndex)
+      .disposed(by: disposeBag)
+    
+    customTabBar.doubleTapEvent
+      .subscribe(with: self, onNext: { owner, index in
+        owner.doubleTapRelay.accept(index)
+      })
       .disposed(by: disposeBag)
   }
 }

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
@@ -59,7 +59,9 @@ public final class FCMReactorImp: FCMReactor {
     case let .updateItem(index):
       return .just(.updateItem(index: index))
     case let .doubleTap(index):
-      return .just(.scrollToTop(index == 2))
+      let scrollObservable = Observable.just(Mutation.scrollToTop(index == 2))
+      let resetTabObservable = Observable.just(Mutation.resetTabEvent)
+      return Observable.concat([scrollObservable, resetTabObservable])
     }
   }
   
@@ -85,6 +87,8 @@ public final class FCMReactorImp: FCMReactor {
       newState.isHiddenEdgePage = isHidden
     case let .scrollToTop(isDoubleTapped):
       newState.isDoubleTap = isDoubleTapped
+    case .resetTabEvent:
+      newState.isDoubleTap = false
     }
     return newState
   }

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
@@ -58,6 +58,8 @@ public final class FCMReactorImp: FCMReactor {
       return selectedItemAction(item: item)
     case let .updateItem(index):
       return .just(.updateItem(index: index))
+    case let .doubleTap(index):
+      return .just(.scrollToTop(index == 2))
     }
   }
   
@@ -81,6 +83,8 @@ public final class FCMReactorImp: FCMReactor {
       newState.isLastPage = isLast
     case let .isHiddenEdgePage(isHidden):
       newState.isHiddenEdgePage = isHidden
+    case let .scrollToTop(isDoubleTapped):
+      newState.isDoubleTap = isDoubleTapped
     }
     return newState
   }

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
@@ -258,6 +258,18 @@ extension FCMViewControllerImp: View {
         owner.edgeView.isHidden = isHidden
       }
       .disposed(by: disposeBag)
+    
+    reactor.state
+      .map{ $0.isDoubleTap }
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.asyncInstance) 
+      .subscribe(with: self, onNext: { owner, isTapped in
+        if isTapped {
+          owner.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
+          owner.reactor?.action.onNext(.doubleTap(nil))
+        }
+      })
+      .disposed(by: disposeBag)
   }
   
   public func bindEvent() {

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
@@ -260,9 +260,11 @@ extension FCMViewControllerImp: View {
       .disposed(by: disposeBag)
     
     reactor.state
-      .map{ $0.isDoubleTap }
+      .map { $0.isDoubleTap }
       .distinctUntilChanged()
-      .observe(on: MainScheduler.asyncInstance) 
+      .filter { $0 }
+      .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
+      .observe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, isTapped in
         if isTapped {
           owner.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
@@ -252,7 +252,6 @@ extension FCMViewControllerImp: View {
     reactor.state
       .map { $0.isHiddenEdgePage }
       .distinctUntilChanged()
-      .debug()
       .asDriver(onErrorJustReturn: false)
       .drive(with: self) { owner, isHidden in
         owner.edgeView.isHidden = isHidden

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
@@ -260,16 +260,12 @@ extension FCMViewControllerImp: View {
       .disposed(by: disposeBag)
     
     reactor.state
-      .map { $0.isDoubleTap }
+      .map{ $0.isDoubleTap }
       .distinctUntilChanged()
-      .filter { $0 }
-      .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
+      .filter { $0 } // 여기서 true인 값만 거르고
       .observe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, isTapped in
-        if isTapped {
-          owner.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
-          owner.reactor?.action.onNext(.doubleTap(nil))
-        }
+        owner.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true) // true인 경우에는 상단 이동
       })
       .disposed(by: disposeBag)
   }

--- a/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
@@ -18,6 +18,7 @@ public enum FCMReactorAction {
   case refreshList
   case selectItem(item: FCMItemModel)
   case updateItem(index: IndexPath)
+  case doubleTap(Int?)
 }
 
 public enum FCMReactorMutation {
@@ -29,6 +30,7 @@ public enum FCMReactorMutation {
   case nextCursor(cursor: String?)
   case isLastPage(Bool)
   case isHiddenEdgePage(Bool)
+  case scrollToTop(Bool)
 }
 
 public struct FCMReactorState {
@@ -38,6 +40,7 @@ public struct FCMReactorState {
   public var nextCursor: String? = nil
   public var isLastPage: Bool = false
   public var isHiddenEdgePage: Bool = true
+  public var isDoubleTap: Bool = false
 }
 
 public protocol FCMReactor: Reactor where Action == FCMReactorAction, Mutation == FCMReactorMutation, State == FCMReactorState {

--- a/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
@@ -31,6 +31,7 @@ public enum FCMReactorMutation {
   case isLastPage(Bool)
   case isHiddenEdgePage(Bool)
   case scrollToTop(Bool)
+  case resetTabEvent
 }
 
 public struct FCMReactorState {

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
@@ -77,13 +77,15 @@ public final class FeedReactorImp: FeedReactor {
         .observe(on: MainScheduler.asyncInstance)
     case let .endedBoost(recordId, count):
       return postBoostCount(recordId: recordId, count: count)
-        .observe(on: MainScheduler.asyncInstance) 
+        .observe(on: MainScheduler.asyncInstance)
     case .profileTapped(let feedData):
       return .just(.moveToProfile(memberId: feedData.authorId, nickName: feedData.nickname))
     case .checkScrollItem:
       return checkScrollEvent()
     case let .doubleTap(index):
-      return .just(.scrollToTop(index == 1))
+      let scrollObservable = Observable.just(Mutation.scrollToTop(index == 1))
+      let resetTabObservable = Observable.just(Mutation.resetTabEvent)
+      return Observable.concat([scrollObservable, resetTabObservable])
     }
   }
   
@@ -107,6 +109,8 @@ public final class FeedReactorImp: FeedReactor {
       newState.scrollToFeedItem = id
     case let .scrollToTop(isDoubleTapped):
       newState.isDoubleTap = isDoubleTapped
+    case .resetTabEvent:
+      newState.isDoubleTap = false
     }
     return newState
   }

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
@@ -82,6 +82,8 @@ public final class FeedReactorImp: FeedReactor {
       return .just(.moveToProfile(memberId: feedData.authorId, nickName: feedData.nickname))
     case .checkScrollItem:
       return checkScrollEvent()
+    case let .doubleTap(index):
+      return .just(.scrollToTop(index == 1))
     }
   }
   
@@ -103,6 +105,8 @@ public final class FeedReactorImp: FeedReactor {
       coordinator.startProfile(memberId: memberId, nickName: nickName)
     case let .scrollToFeedItem(id):
       newState.scrollToFeedItem = id
+    case let .scrollToTop(isDoubleTapped):
+      newState.isDoubleTap = isDoubleTapped
     }
     return newState
   }

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
@@ -169,16 +169,17 @@ extension FeedViewControllerImp: View {
       .disposed(by: disposeBag)
     
     reactor.state
-      .map{ $0.isDoubleTap }
+      .map { $0.isDoubleTap }
       .distinctUntilChanged()
-      .observe(on: MainScheduler.asyncInstance) 
-      .subscribe(with: self, onNext: { owner, isTapped in
-        if isTapped {
-          owner.feed.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
-          owner.reactor?.action.onNext(.doubleTap(nil))
-        }
+      .filter { $0 }
+      .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
+      .observe(on: MainScheduler.instance)
+      .subscribe(with: self, onNext: { owner, _ in
+        owner.feed.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
+        owner.reactor?.action.onNext(.doubleTap(nil))
       })
       .disposed(by: disposeBag)
+
   }
   
   public func bindEvent() {

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
@@ -169,17 +169,14 @@ extension FeedViewControllerImp: View {
       .disposed(by: disposeBag)
     
     reactor.state
-      .map { $0.isDoubleTap }
+      .map{ $0.isDoubleTap }
       .distinctUntilChanged()
       .filter { $0 }
-      .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
       .observe(on: MainScheduler.instance)
-      .subscribe(with: self, onNext: { owner, _ in
+      .subscribe(with: self, onNext: { owner, isTapped in
         owner.feed.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
-        owner.reactor?.action.onNext(.doubleTap(nil))
       })
       .disposed(by: disposeBag)
-
   }
   
   public func bindEvent() {

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
@@ -170,10 +170,12 @@ extension FeedViewControllerImp: View {
     
     reactor.state
       .map{ $0.isDoubleTap }
-      .observe(on: MainScheduler.instance)
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.asyncInstance) 
       .subscribe(with: self, onNext: { owner, isTapped in
         if isTapped {
           owner.feed.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
+          owner.reactor?.action.onNext(.doubleTap(nil))
         }
       })
       .disposed(by: disposeBag)

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
@@ -88,7 +88,7 @@ public final class FeedViewControllerImp<R: FeedReactor>: UIViewController, Feed
           .grow(1)
       }
   }
-
+  
   private func showCoachView() {
     if UserDefaults.bool(forUserDefaultsKey: .isFirstFeedAppear) {
       let scenes = UIApplication.shared.connectedScenes
@@ -167,9 +167,19 @@ extension FeedViewControllerImp: View {
         owner.feed.scrollToRecord(withId: recordId, animated: true)
       }
       .disposed(by: disposeBag)
+    
+    reactor.state
+      .map{ $0.isDoubleTap }
+      .observe(on: MainScheduler.instance)
+      .subscribe(with: self, onNext: { owner, isTapped in
+        if isTapped {
+          owner.feed.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
+        }
+      })
+      .disposed(by: disposeBag)
   }
   
   public func bindEvent() {
-
+    
   }
 }

--- a/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
@@ -23,6 +23,7 @@ public enum FeedReactorAction {
   case endedBoost(recordId: Int, count: Int)
   case profileTapped(WalWalFeedModel)
   case checkScrollItem
+  case doubleTap(Int)
 }
 
 public enum FeedReactorMutation {
@@ -32,6 +33,7 @@ public enum FeedReactorMutation {
   case updateBoost
   case moveToProfile(memberId: Int, nickName: String)
   case scrollToFeedItem(id: Int?)
+  case scrollToTop(Bool)
 }
 
 public struct FeedReactorState {
@@ -41,6 +43,8 @@ public struct FeedReactorState {
   public var nextCursor: String? = nil
   public var feedFetchEnded: Bool = false
   @Pulse public var scrollToFeedItem: Int? = nil
+  public var isDoubleTap: Bool = false
+  
   public init() {  }
 }
 

--- a/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
@@ -34,6 +34,7 @@ public enum FeedReactorMutation {
   case moveToProfile(memberId: Int, nickName: String)
   case scrollToFeedItem(id: Int?)
   case scrollToTop(Bool)
+  case resetTabEvent
 }
 
 public struct FeedReactorState {

--- a/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
@@ -23,7 +23,7 @@ public enum FeedReactorAction {
   case endedBoost(recordId: Int, count: Int)
   case profileTapped(WalWalFeedModel)
   case checkScrollItem
-  case doubleTap(Int)
+  case doubleTap(Int?)
 }
 
 public enum FeedReactorMutation {


### PR DESCRIPTION
## 📌 개요
- issue: #273 

## ✍️ 변경사항
- TabBarItem에 DoubleTap 이벤트 상태 추가했습니다. 
- 피드와 알림 목록 뷰에서 탭 아이템 더블 탭시 최상단으로 이동하는 기능 구현했습니다.

## 📷 스크린샷
| 피드 탭 | 알림 목록 탭|
|:---:|:---:|
| <img src = "https://github.com/user-attachments/assets/73b83162-a3f8-42be-834a-aa89fc1be257" width = "375px"> |<img src = "https://github.com/user-attachments/assets/81787b26-abb6-4a89-ba17-68a85473a80b" width = "375px">  |

## 🛠️ **Technical Concerns(기술적 고민)**
탭바 아이템 -> 탭바VC -> 탭바코디네이터(부모) -> 피드/알림 코디네이터 (자식) -> Reactor 순으로 이벤트 전달해서 구현했는데, 더 좋은 방법이 있을지 궁금합니다!  