### PR TITLE
얼럿 이벤트 처리 이슈 수정

### DIFF
--- a/WalWal/Features/Splash/SplashPresenter/Implement/Views/SplashViewImp.swift
+++ b/WalWal/Features/Splash/SplashPresenter/Implement/Views/SplashViewImp.swift
@@ -110,10 +110,16 @@ extension SplashViewControllerImp: View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
-    WalWalAlert.shared.resultRelay
-      .map { _ in Reactor.Action.moveUpdate }
-      .bind(to: reactor.action)
-      .disposed(by: disposeBag)
+    Observable.combineLatest(
+      WalWalAlert.shared.resultRelay,
+      AppUpdateManager.shared.updateRequest
+    )
+    .map { $0.1 }
+    .distinctUntilChanged()
+    .filter { $0 }
+    .map { _ in Reactor.Action.moveUpdate }
+    .bind(to: reactor.action)
+    .disposed(by: disposeBag)
       
   }
   

--- a/WalWal/Utility/Sources/AppUpdataManager.swift
+++ b/WalWal/Utility/Sources/AppUpdataManager.swift
@@ -12,7 +12,7 @@ import RxSwift
 public final class AppUpdateManager {
   
   public static let shared = AppUpdateManager()
-  public private(set) var updateRequest = PublishSubject<Void>()
+  public private(set) var updateRequest = PublishSubject<Bool>()
   
   private init() {}
   
@@ -37,9 +37,7 @@ public final class AppUpdateManager {
         guard let window = windowScene?.windows.first else { return }
         
         let isNewVersionAvailable = currentVersion.compare(appStoreVersion, options: .numeric) == .orderedAscending
-        if isNewVersionAvailable {
-          self.updateRequest.onNext(())
-        }
+        self.updateRequest.onNext(isNewVersionAvailable)
       }
     }
   }


### PR DESCRIPTION
## 📌 개요
신고 얼럿 버튼 눌렀을 때 앱스토어로 이동하는 문제 해결

## ✍️ 변경사항
- 신고 얼럿에서 resultRelay 이벤트가 발생할 때 `SplashViewImp`에서 구독하고 있던 WalWalAlert의 resultRelay 이벤트가 같이 처리되는 문제 발생
  - WalWalAlert가 싱글톤으로 구현되어있어 resultRelay를 공유하게 되어 문제 발생
- `AppUpdateManager`의 `updateRequest`의 타입을 Bool로 변경하고, 해당 이벤트와  WalWalAlert의 resultRelay가 모두 발생해야 앱스토어 이동 이벤트를 처리하도록 수정
```swift
Observable.combineLatest(
      WalWalAlert.shared.resultRelay,
      AppUpdateManager.shared.updateRequest
    )
    .map { $0.1 }
    .distinctUntilChanged()
    .filter { $0 }
    .map { _ in Reactor.Action.moveUpdate }
    .bind(to: reactor.action)
    .disposed(by: disposeBag)
```
## 📷 스크린샷

## 🛠️ **Technical Concerns(기술적 고민)**
WalwalAlert의 버튼 이벤트를 알맞게 처리할 더 좋은 방법이 있을까?