### PR TITLE
기록 상세 댓글 연결

### DIFF
--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
@@ -15,6 +15,7 @@ import MembersDependencyFactory
 import FeedDependencyFactory
 import ImageDependencyFactory
 import RecordsDependencyFactory
+import CommentDependencyFactory
 import SafariServices
 
 import BaseCoordinator
@@ -45,6 +46,7 @@ public final class MyPageCoordinatorImp: MyPageCoordinator {
   private let feedDependencyFactory: FeedDependencyFactory
   private let imageDependencyFactory: ImageDependencyFactory
   private let recordsDependencyFactory: RecordsDependencyFactory
+  private let commentDependencyFactory: CommentDependencyFactory
   
   public required init(
     navigationController: UINavigationController,
@@ -55,7 +57,8 @@ public final class MyPageCoordinatorImp: MyPageCoordinator {
     membersDependencyFactory: MembersDependencyFactory,
     FeedDependencyFactory: FeedDependencyFactory,
     imageDependencyFactory: ImageDependencyFactory,
-    recordsDependencyFactory: RecordsDependencyFactory
+    recordsDependencyFactory: RecordsDependencyFactory,
+    commentDependencyFactory: CommentDependencyFactory
   ) {
     self.navigationController = navigationController
     self.parentCoordinator = parentCoordinator
@@ -66,6 +69,7 @@ public final class MyPageCoordinatorImp: MyPageCoordinator {
     self.feedDependencyFactory = FeedDependencyFactory
     self.imageDependencyFactory = imageDependencyFactory
     self.recordsDependencyFactory = recordsDependencyFactory
+    self.commentDependencyFactory = commentDependencyFactory
     bindChildToParentAction()
     bindState()
   }
@@ -93,6 +97,8 @@ public final class MyPageCoordinatorImp: MyPageCoordinator {
           owner.showPrivacyPageVC()
         case .showServiceInfoPage:
           owner.showServicePageVC()
+        case let .showCommentView(recordId: recordId):
+          owner.showComment(recordId: recordId)
         }
       })
       .disposed(by: disposeBag)
@@ -278,6 +284,24 @@ extension MyPageCoordinatorImp {
     
     tabBarViewController.hideCustomTabBar()
     self.presentViewController(viewController: profileEditVC, style: .fullScreen)
+  }
+  
+  public func showComment(recordId: Int) {
+    let getCommentUseCase = commentDependencyFactory.injectGetCommentsUseCase()
+    let postCommentUseCase = commentDependencyFactory.injectPostCommentUsecase()
+    let flatternedCommentUseCase = commentDependencyFactory.injectFlattenCommentsUsecase()
+    let reactor = commentDependencyFactory.injectCommentReactor(
+      getCommentsUsecase: getCommentUseCase,
+      postCommentUsecase: postCommentUseCase,
+      flattenCommentUsecase: flatternedCommentUseCase,
+      recordId: recordId
+    )
+    let vc = commentDependencyFactory.injectCommentViewController(reactor: reactor)
+    self.presentViewController(
+      viewController: vc,
+      style: .overFullScreen,
+      animated: false
+    )
   }
 }
 

--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Interface/MyPageCoordinator.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Interface/MyPageCoordinator.swift
@@ -28,6 +28,7 @@ public enum MyPageCoordinatorFlow: CoordinatorFlow {
   case showProfileSetting
   case showPrivacyInfoPage
   case showServiceInfoPage
+  case showCommentView(recordId: Int)
 }
 
 public protocol MyPageCoordinator: BaseCoordinator
@@ -39,4 +40,6 @@ where Flow == MyPageCoordinatorFlow,
     memberId: Int,
     nickName: String
   )
+  
+  func showComment(recordId: Int)
 }

--- a/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
+++ b/WalWal/Coordinators/WalWalTabBar/WalWalTabBarCoordinator/Implement/WalWalTabBarCoordinatorImp.swift
@@ -320,7 +320,8 @@ extension WalWalTabBarCoordinatorImp {
       membersDependencyFactory: membersDependencyFactory,
       feedDependencyFactory: feedDependencyFactory,
       imageDependencyFactory: imageDependencyFactory,
-      recordsDependencyFactory: recordDependencyFactory
+      recordsDependencyFactory: recordDependencyFactory,
+      commentDependencyFactory: commentDependencyFactory
     )
     myPageCoordinator.start()
     return myPageCoordinator
@@ -338,7 +339,8 @@ extension WalWalTabBarCoordinatorImp {
       membersDependencyFactory: membersDependencyFactory,
       feedDependencyFactory: feedDependencyFactory,
       imageDependencyFactory: imageDependencyFactory,
-      recordsDependencyFactory: recordDependencyFactory
+      recordsDependencyFactory: recordDependencyFactory,
+      commentDependencyFactory: commentDependencyFactory
     )
     profileCoordinator.startProfile(memberId: memberId, nickName: nickName)
   }

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
@@ -14,6 +14,7 @@ import MembersDependencyFactory
 import FeedDependencyFactory
 import ImageDependencyFactory
 import RecordsDependencyFactory
+import CommentDependencyFactory
 
 import BaseCoordinator
 import MyPageCoordinator
@@ -48,7 +49,8 @@ public class MyPageDependencyFactoryImp: MyPageDependencyFactory {
     membersDependencyFactory: MembersDependencyFactory,
     feedDependencyFactory: FeedDependencyFactory,
     imageDependencyFactory: ImageDependencyFactory,
-    recordsDependencyFactory: RecordsDependencyFactory
+    recordsDependencyFactory: RecordsDependencyFactory,
+    commentDependencyFactory: CommentDependencyFactory
   ) -> any MyPageCoordinator {
     return MyPageCoordinatorImp(
       navigationController: navigationController,
@@ -59,7 +61,8 @@ public class MyPageDependencyFactoryImp: MyPageDependencyFactory {
       membersDependencyFactory: membersDependencyFactory,
       FeedDependencyFactory: feedDependencyFactory,
       imageDependencyFactory: imageDependencyFactory,
-      recordsDependencyFactory: recordsDependencyFactory
+      recordsDependencyFactory: recordsDependencyFactory,
+      commentDependencyFactory: commentDependencyFactory
     )
   }
   

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
@@ -32,6 +32,8 @@ import ImageDomain
 import RecordsDependencyFactory
 import RecordsDomain
 
+import CommentDependencyFactory
+
 public protocol MyPageDependencyFactory {
   
   func makeMyPageCoordinator(
@@ -42,7 +44,8 @@ public protocol MyPageDependencyFactory {
     membersDependencyFactory: MembersDependencyFactory,
     feedDependencyFactory: FeedDependencyFactory,
     imageDependencyFactory: ImageDependencyFactory,
-    recordsDependencyFactory: RecordsDependencyFactory
+    recordsDependencyFactory: RecordsDependencyFactory,
+    commentDependencyFactory: CommentDependencyFactory
   ) -> any MyPageCoordinator
   
   func injectMyPageRepository() -> MyPageRepository

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
@@ -132,7 +132,7 @@ public final class FeedReactorImp: FeedReactor {
     case let .showMenu(recordId):
       coordinator.destination.accept(.showFeedMenu(recordId: recordId))
     case let .moveToComment(recordId: recordId):
-      coordinator.destination.accept(.showCommentView(recordId: recordId)) // 여기 댓글 이동으로 변경 필요
+      coordinator.destination.accept(.showCommentView(recordId: recordId)) 
     }
     return newState
   }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/RecordDetailReactorImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Reactors/RecordDetailReactorImp.swift
@@ -67,6 +67,8 @@ public final class RecordDetailReactorImp: RecordDetailReactor {
       return .just(Mutation.moveToBack)
     case let .isHiddenTabBar(isHidden):
       return configTabBar(isHidden)
+    case let .commentTapped(recordId: recordId):
+      return .just(.moveToComment(recordId: recordId))
     }
   }
   
@@ -83,6 +85,8 @@ public final class RecordDetailReactorImp: RecordDetailReactor {
       newState.feedErrorMessage = error
     case .moveToBack:
       coordinator.popViewController(animated: true)
+    case let .moveToComment(recordId: recordId):
+      coordinator.destination.accept(.showCommentView(recordId: recordId)) 
     }
     
     return newState

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/RecordDetailViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/RecordDetailViewImp.swift
@@ -160,11 +160,19 @@ extension RecordDetailViewControllerImp: View {
       }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+    
+    feed.commentButtonTapped
+      .throttle(.microseconds(300), scheduler: MainScheduler.instance)
+      .map { Reactor.Action.commentTapped(recordId: $0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
   }
   
   public func bindState(reactor: R) {
     reactor.state
       .map {  $0.feedData }
+      .distinctUntilChanged()
       .observe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, feed in
         owner.feed.addNewData(feed)

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/RecordDetailReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/RecordDetailReactor.swift
@@ -22,6 +22,7 @@ public enum RecordDetailReactorAction {
   case loadFeed(memberId: Int, cursorDate: String?)
   case tapBackButton
   case isHiddenTabBar(Bool)
+  case commentTapped(recordId: Int)
 }
 
 public enum RecordDetailReactorMutation {
@@ -29,6 +30,7 @@ public enum RecordDetailReactorMutation {
   case userFeedReachEnd(newRecord: [WalWalFeedModel])
   case userFeedFetchFailed(errorMessage: String)
   case moveToBack
+  case moveToComment(recordId: Int)
 }
 
 public struct RecordDetailReactorState {


### PR DESCRIPTION
## 📌 개요
- issue: #292 

## ✍️ 변경사항
피드와 동일한 방법으로 기록 상세에서 댓글을 볼 수 있도록 연결했습니다. 
중복으로 데이터가 쌓이는 걸 막기 위해 `.distinctUntilChanged()`을 추가했습니다. 
https://github.com/depromeet/WalWal-iOS/blob/8a96fff08c821459b383e6db25a3d9aa1d11f0e9/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/RecordDetailViewImp.swift#L173-L177

## 📷 스크린샷
https://github.com/user-attachments/assets/2ff51991-757a-4556-b7d3-e8871c5ea3cf



## 🛠️ **Technical Concerns(기술적 고민)**
