### PR TITLE
댓글 레이아웃 수정

### DIFF
--- a/WalWal/DesignSystem/Sources/CustomInputBox/CustomInputBox.swift
+++ b/WalWal/DesignSystem/Sources/CustomInputBox/CustomInputBox.swift
@@ -219,8 +219,7 @@ extension Reactive where Base: CustomInputBox {
   /// `inputBox.rx.textEndEditing.onNext()`
   public var textEndEditing: Binder<Void> {
     return Binder(base) { target, _ in
-      target.textView.resignFirstResponder()
-      target.textView.text = nil
+      target.textView.endEditing(true)
     }
   }
   

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Views/Cells/CommentCell.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Views/Cells/CommentCell.swift
@@ -28,11 +28,6 @@ final class CommentCell: UITableViewCell, ReusableView {
   private let profileImageAndBodyContainer = UIView()
   private let bodyContainer = UIView()
   private let nicknameAndTimeContainer = UIView()
-  
-  private let profileImageContainer = UIView()
-  private let nicknameContainer = UIView()
-  private let timeLabelContainer = UIView()
-  private let contentLabelContainer = UIView()
   private let replyButtonContainer = UIView()
   
   public var parentId: Int? = nil
@@ -80,7 +75,6 @@ final class CommentCell: UITableViewCell, ReusableView {
     replyButton.rx.tapped
       .withUnretained(self)
       .map{ owner, _ in return owner.parentId }
-      .debug()
       .bind(to: parentIdGetted)
       .disposed(by: disposeBag)
   }
@@ -125,11 +119,20 @@ final class CommentCell: UITableViewCell, ReusableView {
       .justifyContent(.spaceBetween)
       .define { flex in
         flex.addItem(profileImageAndBodyContainer)
-        flex.addItem(replyButton)
+        flex.addItem(replyButtonContainer)
           .marginTop(8)
           .marginLeft(42)
         flex.addItem()
           .height(20)
+      }
+    
+    replyButtonContainer.flex
+      .direction(.row)
+      .justifyContent(.spaceBetween)
+      .define {
+        $0.addItem(replyButton)
+        $0.addItem()
+          .grow(1)
       }
     
     profileImageAndBodyContainer.flex

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Views/CommentViewImp.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Views/CommentViewImp.swift
@@ -119,7 +119,7 @@ public final class CommentViewControllerImp<R: CommentReactor>: UIViewController
   public func setAttribute() {
     view.backgroundColor = .clear
     view.addSubview(dimView)
-    view.addSubview(rootContainerView)
+    dimView.addSubview(rootContainerView)
     
     rootContainerView.layer.cornerRadius = 30
     rootContainerView.layer.maskedCorners = CACornerMask(arrayLiteral: .layerMinXMinYCorner, .layerMaxXMinYCorner)
@@ -197,17 +197,30 @@ public final class CommentViewControllerImp<R: CommentReactor>: UIViewController
   private func keyboardShowLayout() {
     let keyboardTop = view.pin.keyboardArea.height
     
-    inputBox.flex
-      .marginBottom(keyboardTop)
-      .height(58)
     rootContainerView.flex
       .layout()
+    
+    rootContainerView.pin
+      .top(65.adjustedHeight)
+      .bottom(0)
+    
+    inputBox.pin
+      .bottom(keyboardTop)
+    
+    tableView.pin
+      .above(of: inputBox)
+      .below(of: headerContainerView)
   }
   
   /// 키보드 내려갔을 때 레이아웃 재설정
   private func keyboardHideLayout() {
-    inputBox.flex
-      .marginBottom(view.pin.safeArea.bottom)
+    rootContainerView.pin
+      .bottom(0)
+      .height(580.adjustedHeight)
+    
+    inputBox.pin
+      .bottom(view.pin.safeArea.bottom)
+    
     rootContainerView.flex
       .layout()
   }

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Views/CommentViewImp.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Views/CommentViewImp.swift
@@ -119,7 +119,7 @@ public final class CommentViewControllerImp<R: CommentReactor>: UIViewController
   public func setAttribute() {
     view.backgroundColor = .clear
     view.addSubview(dimView)
-    dimView.addSubview(rootContainerView)
+    view.addSubview(rootContainerView)
     
     rootContainerView.layer.cornerRadius = 30
     rootContainerView.layer.maskedCorners = CACornerMask(arrayLiteral: .layerMinXMinYCorner, .layerMaxXMinYCorner)
@@ -197,30 +197,17 @@ public final class CommentViewControllerImp<R: CommentReactor>: UIViewController
   private func keyboardShowLayout() {
     let keyboardTop = view.pin.keyboardArea.height
     
+    inputBox.flex
+      .marginBottom(keyboardTop)
+      .height(58)
     rootContainerView.flex
       .layout()
-    
-    rootContainerView.pin
-      .top(65.adjustedHeight)
-      .bottom(0)
-    
-    inputBox.pin
-      .bottom(keyboardTop)
-    
-    tableView.pin
-      .above(of: inputBox)
-      .below(of: headerContainerView)
   }
   
   /// 키보드 내려갔을 때 레이아웃 재설정
   private func keyboardHideLayout() {
-    rootContainerView.pin
-      .bottom(0)
-      .height(580.adjustedHeight)
-    
-    inputBox.pin
-      .bottom(view.pin.safeArea.bottom)
-    
+    inputBox.flex
+      .marginBottom(view.pin.safeArea.bottom)
     rootContainerView.flex
       .layout()
   }


### PR DESCRIPTION
## 📌 개요
댓글 화면 레이아웃 수정

## ✍️ 변경사항
- 키보드 내릴 때 댓글 입력해둔 텍스트 뷰의 텍스트 사라짐 오류 수정
- 답글달기 버튼이 있는 수평 영역 중 빈 곳을 눌러도 답글달기가 시작되는 문제 수정
  - 답글달기 버튼 영역 만 눌러야 가능하도록!

## 📷 스크린샷
|수정 전|수정 후|
|:-----:|:-----:|
|<img src="https://github.com/user-attachments/assets/c326e239-7ef1-4faf-9fa5-5572879e27b7" width="351">|<img src="https://github.com/user-attachments/assets/376300eb-d145-44b5-8471-ce09b43b940f" width="351">|



## 🛠️ **Technical Concerns(기술적 고민)**
