### PR TITLE
피드셀에 댓글 개수 업데이트

### DIFF
--- a/WalWal/Coordinators/Comment/CommentCoordinator/Implement/CommentCoordinatorImp.swift
+++ b/WalWal/Coordinators/Comment/CommentCoordinator/Implement/CommentCoordinatorImp.swift
@@ -1,0 +1,107 @@
+//
+//  CommentCoordinatorImp.swift
+//
+//  Comment
+//
+//  Created by 이지희
+//
+
+import UIKit
+import CommentDependencyFactory
+import BaseCoordinator
+import CommentCoordinator
+
+import RxSwift
+import RxCocoa
+
+public final class CommentCoordinatorImp: CommentCoordinator {
+  
+  public typealias Action = CommentCoordinatorAction
+  public typealias Flow = CommentCoordinatorFlow
+  
+  public let disposeBag = DisposeBag()
+  public let destination = PublishRelay<Flow>()
+  public let requireFromChild = PublishSubject<CoordinatorEvent<Action>>()
+  public let navigationController: UINavigationController
+  public weak var parentCoordinator: (any BaseCoordinator)?
+  public var childCoordinator: (any BaseCoordinator)?
+  public var baseViewController: UIViewController?
+  
+  public var commentDependencyFactory: CommentDependencyFactory
+  
+  private let recordId: Int
+  
+  public required init(
+    navigationController: UINavigationController,
+    parentCoordinator: (any BaseCoordinator)?,
+    commentDependencyFactory: CommentDependencyFactory,
+    recordId: Int
+  ) {
+    self.recordId = recordId
+    self.navigationController = navigationController
+    self.parentCoordinator = parentCoordinator
+    self.commentDependencyFactory = commentDependencyFactory
+    bindChildToParentAction()
+    bindState()
+  }
+  
+  public func bindState() {
+    destination
+      .subscribe(with: self, onNext: { owner, flow in
+        switch flow { }
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  /// 자식 Coordinator들로부터 전달된 Action을 근거로, 이후 동작을 정의합니다.
+  /// 여기도, Comment이 부모로써 Child로부터 받은 event가 있다면 처리해주면 됨.
+  public func handleChildEvent<T: ParentAction>(_ event: T) {
+//    if let __Event = event as? CoordinatorEvent<__CoordinatorAction> {
+//      handle__Event(__Event)
+//    } else if let __Event = event as? CoordinatorEvent<__CoordinatorAction> {
+//      handle__Event(__Event)
+//    }
+  }
+  
+  public func start() {
+    let getCommentsUsecase = commentDependencyFactory.injectGetCommentsUseCase()
+    let postCommentUsecase = commentDependencyFactory.injectPostCommentUsecase()
+    let flattenCommentUsecase = commentDependencyFactory.injectFlattenCommentsUsecase()
+    
+    let reactor = commentDependencyFactory.injectCommentReactor(
+      coordinator: self,
+      getCommentsUsecase: getCommentsUsecase,
+      postCommentUsecase: postCommentUsecase,
+      flattenCommentUsecase: flattenCommentUsecase,
+      recordId: self.recordId
+    )
+    let commentVC = commentDependencyFactory.injectCommentViewController(reactor: reactor)
+    self.baseViewController = commentVC
+    self.presentViewController(viewController: commentVC, style: .overFullScreen, animated: false)
+  }
+}
+
+// MARK: - Handle Child Actions
+
+extension CommentCoordinatorImp {
+
+}
+
+// MARK: - Create and Start(Show) with Flow(View)
+
+extension CommentCoordinatorImp {
+
+}
+
+
+
+// MARK: - Comment(자식)의 동작 결과, __(부모)에게 특정 Action을 요청합니다. 실제 사용은 reactor에서 호출
+
+extension CommentCoordinatorImp {
+  public func reloadFeedAt(_ recordId: Int) {
+    print("피드 업데이트, 부모 이밴트 요청")
+    self.dismissViewController { [weak self] in
+      self?.requireFromChild.onNext(.requireParentAction(.dismissComment(recordId)))
+    }
+  }
+}

--- a/WalWal/Coordinators/Comment/CommentCoordinator/Interface/CommentCoordinator.swift
+++ b/WalWal/Coordinators/Comment/CommentCoordinator/Interface/CommentCoordinator.swift
@@ -1,0 +1,24 @@
+//
+//  CommentCoordinatorInterface.swift
+//
+//  Comment
+//
+//  Created by 이지희
+//
+
+import UIKit
+import BaseCoordinator
+
+public enum CommentCoordinatorAction: ParentAction {
+  case dismissComment(Int)
+}
+
+public enum CommentCoordinatorFlow: CoordinatorFlow {
+  
+}
+
+public protocol CommentCoordinator: BaseCoordinator
+where Flow == CommentCoordinatorFlow,
+      Action == CommentCoordinatorAction {
+  func reloadFeedAt(_ recordId: Int)
+}

--- a/WalWal/Coordinators/Comment/CommentCoordinator/Project.swift
+++ b/WalWal/Coordinators/Comment/CommentCoordinator/Project.swift
@@ -1,0 +1,23 @@
+//
+//  CommentCoordinatorProject.swift
+//
+//  Comment
+//
+//  Created by 이지희
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.invertedDualTargetProject(
+  name: "CommentCoordinator",
+  platform: .iOS,
+  iOSTargetVersion: "15.0.0",
+  interfaceDependencies: [
+    .Coordinator.Base.Interface
+  ],
+  implementDependencies: [
+    .DependencyFactory.Comment.Interface
+  ]
+)

--- a/WalWal/DependencyFactory/Comment/CommentDependencyFactory/Implement/CommentDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/Comment/CommentDependencyFactory/Implement/CommentDependencyFactoryImp.swift
@@ -11,6 +11,10 @@ import WalWalNetwork
 
 import CommentDependencyFactory
 
+import BaseCoordinator
+import CommentCoordinator
+import CommentCoordinatorImp
+
 import CommentData
 import CommentDataImp
 import CommentDomain
@@ -24,30 +28,45 @@ public class CommentDependencyFactoryImp: CommentDependencyFactory {
     
   }
   
-  public func injectFeedRepository() -> any CommentRepository {
+  public func injectCommentCoordinator(
+    navigationController: UINavigationController,
+    parentCoordinator: any BaseCoordinator,
+    recordId: Int
+  ) -> any CommentCoordinator {
+    return CommentCoordinatorImp (
+      navigationController: navigationController,
+      parentCoordinator: parentCoordinator,
+      commentDependencyFactory: self,
+      recordId: recordId
+    )
+  }
+  
+  public func injectCommentRepository() -> any CommentRepository {
     let networkService = NetworkService()
     return CommentRepositoryImp(networkService: networkService)
   }
   
   public func injectGetCommentsUseCase() -> any GetCommentsUsecase {
-    return GetCommentsUsecaseImp(repository: injectFeedRepository())
+    return GetCommentsUsecaseImp(repository: injectCommentRepository())
   }
   
   public func injectPostCommentUsecase() -> any PostCommentUsecase {
-    return PostCommentUsecaseImp(repository: injectFeedRepository())
+    return PostCommentUsecaseImp(repository: injectCommentRepository())
   }
   
   public func injectFlattenCommentsUsecase() -> any FlattenCommentsUsecase {
     return FlattenCommentsUsecaseImp()
   }
   
-  public func injectCommentReactor(
+  public func injectCommentReactor<T>(
+    coordinator: T,
     getCommentsUsecase: any GetCommentsUsecase,
     postCommentUsecase: any PostCommentUsecase,
     flattenCommentUsecase: any FlattenCommentsUsecase,
     recordId: Int
-  ) -> any CommentReactor {
+  ) -> any CommentReactor where T: CommentCoordinator {
     return CommentReactorImp(
+      coordinator: coordinator,
       getCommentsUsecase: getCommentsUsecase,
       postCommentUsecase: postCommentUsecase,
       flattenCommentUsecase: flattenCommentUsecase,

--- a/WalWal/DependencyFactory/Comment/CommentDependencyFactory/Interface/CommentDependencyFactory.swift
+++ b/WalWal/DependencyFactory/Comment/CommentDependencyFactory/Interface/CommentDependencyFactory.swift
@@ -10,6 +10,7 @@ import UIKit
 
 import BaseCoordinator
 
+import CommentCoordinator
 import CommentData
 import CommentDomain
 import CommentPresenter
@@ -18,25 +19,32 @@ public protocol CommentDependencyFactory {
   
   // MARK: - Repository
   
-  func injectFeedRepository() -> CommentRepository
+  func injectCommentCoordinator(
+    navigationController: UINavigationController,
+    parentCoordinator: any BaseCoordinator,
+    recordId: Int
+  ) -> any CommentCoordinator
+  
+  func injectCommentRepository() -> CommentRepository
   
   // MARK: - UseCase
- 
+  
   func injectGetCommentsUseCase() -> GetCommentsUsecase
   func injectPostCommentUsecase() -> PostCommentUsecase
   func injectFlattenCommentsUsecase() -> FlattenCommentsUsecase
   
   // MARK: - Reactor
   
-  func injectCommentReactor(
-      getCommentsUsecase: GetCommentsUsecase,
-      postCommentUsecase: PostCommentUsecase,
-      flattenCommentUsecase: FlattenCommentsUsecase,
-      recordId: Int
+  func injectCommentReactor<T: CommentCoordinator>(
+    coordinator: T,
+    getCommentsUsecase: GetCommentsUsecase,
+    postCommentUsecase: PostCommentUsecase,
+    flattenCommentUsecase: FlattenCommentsUsecase,
+    recordId: Int
   ) -> any CommentReactor
   
   // MARK: - ViewController
   
   func injectCommentViewController<T: CommentReactor>(reactor: T) -> any CommentViewController
-
+  
 }

--- a/WalWal/DependencyFactory/Comment/CommentDependencyFactory/Project.swift
+++ b/WalWal/DependencyFactory/Comment/CommentDependencyFactory/Project.swift
@@ -20,6 +20,7 @@ let project = Project.invertedDualTargetProject(
   implementDependencies: [
     .Feature.Comment.Data.Implement,
     .Feature.Comment.Domain.Implement,
-    .Feature.Comment.Presenter.Implement
+    .Feature.Comment.Presenter.Implement,
+    .Coordinator.Comment.Implement
   ]
 )

--- a/WalWal/DependencyFactory/Feed/FeedDependencyFactory/Implement/FeedDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/Feed/FeedDependencyFactory/Implement/FeedDependencyFactoryImp.swift
@@ -75,19 +75,25 @@ public class FeedDependencyFactoryImp: FeedDependencyFactory {
     return ReportUseCaseImp(reportRepository: injectReportRepostioy())
   }
   
+  public func injectFetchSingleFeedUseCase() -> FetchSingleFeedUseCase {
+    return FetchSingleFeedUseCaseImp(feedRepository: injectFeedRepository())
+  }
+  
   // MARK: - Reactor
   
   public func injectFeedReactor<T: FeedCoordinator>(
     coordinator: T,
     fetchFeedUseCase: FetchFeedUseCase,
     updateBoostCountUseCase: UpdateBoostCountUseCase,
-    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase
+    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase,
+    fetchSingleFeedUseCase: FetchSingleFeedUseCase
   ) -> any FeedReactor {
     return FeedReactorImp(
       coordinator: coordinator,
       fetchFeedUseCase: fetchFeedUseCase,
       updateBoostCountUseCase: updateBoostCountUseCase,
-      removeGlobalRecordIdUseCase: removeGlobalRecordIdUseCase
+      removeGlobalRecordIdUseCase: removeGlobalRecordIdUseCase,
+      fetchSingleFeedUseCase: fetchSingleFeedUseCase
     )
   }
   

--- a/WalWal/DependencyFactory/Feed/FeedDependencyFactory/Interface/FeedDependencyFactory.swift
+++ b/WalWal/DependencyFactory/Feed/FeedDependencyFactory/Interface/FeedDependencyFactory.swift
@@ -44,13 +44,16 @@ public protocol FeedDependencyFactory {
   
   func injectReportUseCase() -> ReportUseCase
   
+  func injectFetchSingleFeedUseCase() -> FetchSingleFeedUseCase
+  
   // MARK: - Reactor
   
   func injectFeedReactor<T: FeedCoordinator>(
     coordinator: T,
     fetchFeedUseCase: FetchFeedUseCase,
     updateBoostCountUseCase: UpdateBoostCountUseCase,
-    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase
+    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase,
+    fetchSingleFeedUseCase: FetchSingleFeedUseCase
   ) -> any FeedReactor
   
   func injectFeedMenuReactor<T: FeedCoordinator>(

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Implement/MyPageDependencyFactoryImp.swift
@@ -115,9 +115,14 @@ public class MyPageDependencyFactoryImp: MyPageDependencyFactory {
   public func injectRecordDetailReactor<T: MyPageCoordinator>(
     coordinator: T,
     fetchUserFeedUseCase: FetchUserFeedUseCase,
+    fetchSingleFeedUseCase: FetchSingleFeedUseCase,
     memberId: Int
   ) -> any RecordDetailReactor{
-    return RecordDetailReactorImp(coordinator: coordinator, fetchUserFeedUseCase: fetchUserFeedUseCase, memberId: memberId)
+    return RecordDetailReactorImp(
+      coordinator: coordinator,
+      fetchUserFeedUseCase: fetchUserFeedUseCase,
+      fetchSingleFeedUseCase: fetchSingleFeedUseCase,
+      memberId: memberId)
   }
   
   public func injectRecordDetailViewController<T: RecordDetailReactor>(

--- a/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
+++ b/WalWal/DependencyFactory/MyPage/MyPageDependencyFactory/Interface/MyPageDependencyFactory.swift
@@ -76,6 +76,7 @@ public protocol MyPageDependencyFactory {
   func injectRecordDetailReactor<T: MyPageCoordinator>(
     coordinator: T,
     fetchUserFeedUseCase: FetchUserFeedUseCase,
+    fetchSingleFeedUseCase: FetchSingleFeedUseCase,
     memberId: Int
   ) -> any RecordDetailReactor
   func injectRecordDetailViewController<T: RecordDetailReactor>(

--- a/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
+++ b/WalWal/DesignSystem/Sources/WalWalFeed/WalWalFeed.swift
@@ -230,6 +230,7 @@ public final class WalWalFeed: UIView {
     }
   }
   
+  /// 피드 데이터 불러온 후 추가
   public func addNewData(_ newData: [WalWalFeedModel]) {
     let currentDataCount = currentFeedData.count
     currentFeedData.append(contentsOf: newData)
@@ -239,6 +240,20 @@ public final class WalWalFeed: UIView {
     collectionView.performBatchUpdates({
       collectionView.insertItems(at: newIndexPaths)
     }, completion: nil)
+  }
+  
+  /// 특정 피드만 업데이트
+  public func updateRecord(at recordId: Int, updatedFeed: WalWalFeedModel) {
+    if let index = currentFeedData.firstIndex(where: { $0.recordId == recordId }) {
+      currentFeedData[index] = updatedFeed
+      feedData.accept(currentFeedData)
+      
+      collectionView.performBatchUpdates({
+        collectionView.reloadItems(at: [IndexPath(item: index, section: 0)])
+      }, completion: nil)
+      
+      collectionView.collectionViewLayout.invalidateLayout()
+    }
   }
   
   

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Reactors/CommentReactorImp.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Reactors/CommentReactorImp.swift
@@ -6,6 +6,7 @@
 //  Created by 조용인
 //
 
+import CommentCoordinator
 import CommentDomain
 import CommentPresenter
 
@@ -19,6 +20,7 @@ public final class CommentReactorImp: CommentReactor {
   public typealias State = CommentReactorState
   
   public let initialState: State
+  public let coordinator: any CommentCoordinator
   
   private var recordId: Int
   
@@ -27,11 +29,14 @@ public final class CommentReactorImp: CommentReactor {
   private let flattenCommentUsecase: FlattenCommentsUsecase
   
   public init(
+    coordinator: any CommentCoordinator,
     getCommentsUsecase: GetCommentsUsecase,
     postCommentUsecase: PostCommentUsecase,
     flattenCommentUsecase: FlattenCommentsUsecase,
     recordId: Int
   ) {
+    self.coordinator = coordinator
+    
     self.getCommentsUsecase = getCommentsUsecase
     self.postCommentUsecase = postCommentUsecase
     self.flattenCommentUsecase = flattenCommentUsecase
@@ -101,7 +106,7 @@ public final class CommentReactorImp: CommentReactor {
     case let .setSheetPosition(position):
       newState.sheetPosition = position
     case .dismissSheet:
-      newState.isSheetDismissed = true
+      coordinator.reloadFeedAt(recordId)
     case let .setReplyMode(parentId, isReply):
       newState.parentId = parentId
       newState.isReply = isReply

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Views/CommentViewImp.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Views/CommentViewImp.swift
@@ -287,13 +287,6 @@ extension CommentViewControllerImp: View {
         self.updateSheetPosition(position)
       })
       .disposed(by: disposeBag)
-    
-    reactor.state.map { $0.isSheetDismissed }
-      .filter { $0 }
-      .subscribe(with: self) { owner, isSheetDismissed in
-        owner.dismiss(animated: false)
-      }
-      .disposed(by: disposeBag)
   }
   
   public func bindAction(reactor: R) {

--- a/WalWal/Features/Comment/CommentPresenter/Interface/Reactors/CommentReactor.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Interface/Reactors/CommentReactor.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import CommentDomain
+import CommentCoordinator
 
 import ReactorKit
 import RxSwift
@@ -50,7 +51,10 @@ public struct CommentReactorState {
 
 public protocol CommentReactor: Reactor where Action == CommentReactorAction, Mutation == CommentReactorMutation, State == CommentReactorState {
   
+  var coordinator: any CommentCoordinator { get }
+  
   init(
+    coordinator: any CommentCoordinator,
     getCommentsUsecase: GetCommentsUsecase,
     postCommentUsecase: PostCommentUsecase,
     flattenCommentUsecase: FlattenCommentsUsecase,

--- a/WalWal/Features/Comment/CommentPresenter/Project.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Project.swift
@@ -18,6 +18,7 @@ let project = Project.invertedPresenterWithDemoApp(
     .ThirdParty.ReactorKit,
     
     .Feature.Comment.Domain.Interface,
+    .Coordinator.Comment.Interface,
     .DesignSystem
   ],
   implementDependencies: [

--- a/WalWal/Features/Feed/FeedData/Implement/Endpoint/FeedEndpoint.swift
+++ b/WalWal/Features/Feed/FeedData/Implement/Endpoint/FeedEndpoint.swift
@@ -16,6 +16,7 @@ enum FeedEndpoint<T>: APIEndpoint where T: Decodable {
   typealias ResponseType = T
   case fetchFeed(query: FetchFeedQuery)
   case reports(body: ReportParameter)
+  case fetchSingleFeed(Int)
 }
 
 extension FeedEndpoint {
@@ -29,6 +30,8 @@ extension FeedEndpoint {
       return "/feed"
     case .reports:
       return "/reports"
+    case let .fetchSingleFeed(recordId):
+      return "/feed/\(recordId)"
     }
   }
   
@@ -38,6 +41,8 @@ extension FeedEndpoint {
       return .get
     case .reports:
       return .post
+    case .fetchSingleFeed:
+      return .get
     }
   }
   
@@ -47,12 +52,14 @@ extension FeedEndpoint {
       return .requestQuery(query)
     case let .reports(body):
       return .requestWithbody(body)
+    case .fetchSingleFeed:
+      return .requestPlain
     }
   }
   
   var headerType: HTTPHeaderType {
     switch self {
-    case .fetchFeed, .reports:
+    case .fetchFeed, .reports, .fetchSingleFeed:
       if let accessToken = KeychainWrapper.shared.accessToken {
         return .authorization(accessToken)
       } else{

--- a/WalWal/Features/Feed/FeedData/Implement/Repository/FeedRepositoryImp.swift
+++ b/WalWal/Features/Feed/FeedData/Implement/Repository/FeedRepositoryImp.swift
@@ -27,4 +27,12 @@ public final class FeedRepositoryImp: FeedRepository {
       .asObservable()
       .asSingle()
   }
+  
+  public func fetchSingleFeed(recordId: Int) -> Single<FeedListDTO> {
+    let endPoint = FeedEndpoint<FeedListDTO>.fetchSingleFeed(recordId)
+    return networkService.request(endpoint: endPoint, isNeedInterceptor: true)
+      .compactMap { $0 }
+      .asObservable()
+      .asSingle()
+  }
 }

--- a/WalWal/Features/Feed/FeedData/Interface/Repository/FeedRepository.swift
+++ b/WalWal/Features/Feed/FeedData/Interface/Repository/FeedRepository.swift
@@ -12,4 +12,5 @@ import RxSwift
 
 public protocol FeedRepository {
   func fetchFeedData(memberId: Int?, cursor: String?, limit: Int) -> Single<FeedDTO>
+  func fetchSingleFeed(recordId: Int) -> Single<FeedListDTO>
 }

--- a/WalWal/Features/Feed/FeedDomain/Implement/FetchSingleFeedUseCaseImp.swift
+++ b/WalWal/Features/Feed/FeedDomain/Implement/FetchSingleFeedUseCaseImp.swift
@@ -1,0 +1,30 @@
+//
+//  FetchSingleFeedUseCaseImp.swift
+//  FeedDomain
+//
+//  Created by 이지희 on 10/11/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import Foundation
+import FeedData
+import FeedDomain
+
+import RxSwift
+
+public final class FetchSingleFeedUseCaseImp: FetchSingleFeedUseCase {
+
+  private let feedRepository: FeedRepository
+  
+  public init(feedRepository: FeedRepository) {
+    self.feedRepository = feedRepository
+  }
+  
+  public func execute(recordId: Int) -> Single<FeedListModel> {
+    return feedRepository.fetchSingleFeed(recordId: recordId)
+      .map { dto in
+        let feedModel = FeedListModel(dto: dto)
+        return feedModel
+      }
+  }
+}

--- a/WalWal/Features/Feed/FeedDomain/Interface/FetchSingleFeedUseCase.swift
+++ b/WalWal/Features/Feed/FeedDomain/Interface/FetchSingleFeedUseCase.swift
@@ -1,0 +1,15 @@
+//
+//  FetchSingleFeedUseCase.swift
+//  FeedDomain
+//
+//  Created by 이지희 on 10/11/24.
+//  Copyright © 2024 olderStoneBed.io. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+public protocol FetchSingleFeedUseCase {
+  func execute(recordId: Int) -> Single<FeedListModel>
+}

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
@@ -33,6 +33,7 @@ public final class FeedReactorImp: FeedReactor {
   private let fetchFeedUseCase: FetchFeedUseCase
   private let updateBoostCountUseCase: UpdateBoostCountUseCase
   private let removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase
+  private let fetchSingleFeedUseCase: FetchSingleFeedUseCase
   
   private var isLoading: Bool = false
   
@@ -40,12 +41,14 @@ public final class FeedReactorImp: FeedReactor {
     coordinator: any FeedCoordinator,
     fetchFeedUseCase: FetchFeedUseCase,
     updateBoostCountUseCase: UpdateBoostCountUseCase,
-    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase
+    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase,
+    fetchSingleFeedUseCase: FetchSingleFeedUseCase
   ) {
     self.coordinator = coordinator
     self.fetchFeedUseCase = fetchFeedUseCase
     self.updateBoostCountUseCase = updateBoostCountUseCase
     self.removeGlobalRecordIdUseCase = removeGlobalRecordIdUseCase
+    self.fetchSingleFeedUseCase = fetchSingleFeedUseCase
     
     self.initialState = State()
   }
@@ -104,6 +107,8 @@ public final class FeedReactorImp: FeedReactor {
       return .just(.showMenu(recordId: recordId))
     case let .commentTapped(recordId: recordId):
       return .just(.moveToComment(recordId: recordId))
+    case .refreshFeedData(recordId: let recordId):
+      return fetchUpdatedFeedAt(recordId: recordId)
     }
   }
   
@@ -133,6 +138,10 @@ public final class FeedReactorImp: FeedReactor {
       coordinator.destination.accept(.showFeedMenu(recordId: recordId))
     case let .moveToComment(recordId: recordId):
       coordinator.destination.accept(.showCommentView(recordId: recordId)) 
+    case let .updateFeed(record: updatedFeed):
+      if let updatedFeed {
+        newState.updatedFeed = updatedFeed
+      }
     }
     return newState
   }
@@ -183,6 +192,20 @@ public final class FeedReactorImp: FeedReactor {
       .asObservable()
       .flatMap { _ -> Observable<Mutation> in
         return .just(.updateBoost)
+      }
+  }
+  
+  private func fetchUpdatedFeedAt(recordId: Int) -> Observable<Mutation> {
+    // 여기 특정 피드만 불러오는 걸로 수정 필요
+    return fetchSingleFeedUseCase.execute(recordId: recordId)
+      .asObservable()
+      .withUnretained(self)
+      .flatMap { owner, singleFeed -> Observable<Mutation> in
+        return owner.convertFeedModel(feedList: [singleFeed])
+          .withUnretained(self)
+          .flatMap { owner, feed -> Observable<Mutation> in
+            return .just(.updateFeed(record: feed.first))
+          }
       }
   }
   

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
@@ -189,6 +189,17 @@ extension FeedViewControllerImp: View {
         owner.feed.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)
       })
       .disposed(by: disposeBag)
+    
+    reactor.state
+      .map { $0.updatedFeed }
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .subscribe(with: self) { owner, updatedFeed in
+        if let updatedFeed {
+          owner.feed.updateRecord(at: updatedFeed.recordId, updatedFeed: updatedFeed)
+        }
+      }
+      .disposed(by: disposeBag)
   }
   
   public func bindEvent() {

--- a/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
@@ -26,6 +26,7 @@ public enum FeedReactorAction {
   case doubleTap(Int?)
   case menuTapped(recordId: Int)
   case commentTapped(recordId: Int)
+  case refreshFeedData(recordId: Int)
 }
 
 public enum FeedReactorMutation {
@@ -39,11 +40,13 @@ public enum FeedReactorMutation {
   case resetTabEvent
   case showMenu(recordId: Int)
   case moveToComment(recordId: Int)
+  case updateFeed(record: WalWalFeedModel?)
 }
 
 public struct FeedReactorState {
   @Pulse public var feedErrorMessage: String = ""
   public var feedData: [WalWalFeedModel] = []
+  public var updatedFeed: WalWalFeedModel? = nil
   public var nextCursor: String? = nil
   public var feedFetchEnded: Bool = false
   @Pulse public var scrollToFeedItem: Int? = nil
@@ -59,6 +62,7 @@ public protocol FeedReactor: Reactor where Action == FeedReactorAction, Mutation
     coordinator: any FeedCoordinator,
     fetchFeedUseCase: FetchFeedUseCase,
     updateBoostCountUseCase: UpdateBoostCountUseCase,
-    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase
+    removeGlobalRecordIdUseCase: RemoveGlobalRecordIdUseCase,
+    fetchSingleFeedUseCase: FetchSingleFeedUseCase
   )
 }

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/RecordDetailViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/RecordDetailViewImp.swift
@@ -179,6 +179,17 @@ extension RecordDetailViewControllerImp: View {
         owner.feed.scrollToRecord(withId: owner.recordId, animated: true)
       })
       .disposed(by: disposeBag)
+    
+    reactor.state
+      .map { $0.updatedFeed }
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .subscribe(with: self) { owner, updatedFeed in
+        if let updatedFeed {
+          owner.feed.updateRecord(at: updatedFeed.recordId, updatedFeed: updatedFeed)
+        }
+      }
+      .disposed(by: disposeBag)
   }
   
   public func bindEvent() {

--- a/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/RecordDetailReactor.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Interface/Reactors/RecordDetailReactor.swift
@@ -23,6 +23,7 @@ public enum RecordDetailReactorAction {
   case tapBackButton
   case isHiddenTabBar(Bool)
   case commentTapped(recordId: Int)
+  case refreshFeedData(recordId: Int)
 }
 
 public enum RecordDetailReactorMutation {
@@ -31,6 +32,7 @@ public enum RecordDetailReactorMutation {
   case userFeedFetchFailed(errorMessage: String)
   case moveToBack
   case moveToComment(recordId: Int)
+  case updateFeed(record: WalWalFeedModel?)
 }
 
 public struct RecordDetailReactorState {
@@ -39,6 +41,7 @@ public struct RecordDetailReactorState {
   public var nextCursor: String? = nil
   public var feedFetchEnded: Bool = false
   public var memberId: Int
+  public var updatedFeed: WalWalFeedModel? = nil
   
   public init(memberId: Int) {
     self.memberId = memberId
@@ -55,6 +58,7 @@ public protocol RecordDetailReactor: Reactor where Action == RecordDetailReactor
   init(
     coordinator: any MyPageCoordinator,
     fetchUserFeedUseCase: FetchUserFeedUseCase,
+    fetchSingleFeedUseCase: FetchSingleFeedUseCase,
     memberId: Int
   )
 }

--- a/WalWal/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Project.swift
+++ b/WalWal/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Project.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import ProjectDescription
+@preconcurrency import ProjectDescription
 
 //MARK: - Target Dependency관련 확장 (Target별 상세 Dependency)
 
@@ -44,6 +44,7 @@ enum CoordinatorStr: String {
   case myPage = "MyPage"
   case fcm = "FCM"
   case missionUpload = "MissionUpload"
+  case comment = "Comment"
 }
 
 enum FeatureStr: String {
@@ -134,6 +135,7 @@ extension TargetDependency {
     public struct FCM: WalWalDependency { }
     public struct Feed: WalWalDependency { }
     public struct MissionUpload: WalWalDependency { }
+    public struct Comment: WalWalDependency { }
   }
   
   public struct Feature {
@@ -487,6 +489,10 @@ public extension TargetDependency.Coordinator.FCM {
   static let Implement = Self.project(name: .fcm, isInterface: false)
 }
 
+public extension TargetDependency.Coordinator.Comment {
+  static let Interface = Self.project(name: .comment, isInterface: true)
+  static let Implement = Self.project(name: .comment, isInterface: false)
+}
 
 public extension TargetDependency.ThirdParty {
   private static func framework(name: String) -> TargetDependency {


### PR DESCRIPTION
## 📌 개요
- issue: #297 

## ✍️ 변경사항
댓글창을 닫을 때 댓글 개수 변경 시 반영되도록 수정했습니다. 
- 기존에 별도의 코디네이터 없이 사용하던 화면 전환을 Comment Coordinator를 생성하여 분리했습니다.
- 미션 탭 화면에서 미션 시작 -> 미션 완료 뷰 데이터 통신시 사용하는 base reactor을 사용하여 구현했습니다.

## 📷 스크린샷
| 피드 뷰 | 기록 상세 뷰|
|:---:|:---:|
|![ScreenRecording_10-11-2024 23-09-25_1 (1)](https://github.com/user-attachments/assets/18c70932-8368-4e63-8818-404db58fca9c)|![ScreenRecording_10-12-2024 00-09-29_1 (1)](https://github.com/user-attachments/assets/6acca02d-a0b1-4832-81c6-3bc94be9c78a)|




## 🛠️ **Technical Concerns(기술적 고민)**


