### PR TITLE
미션 완료 카드 이미지 정상화

### DIFF
--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
@@ -183,11 +183,11 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
     
     missionInfoContainer.flex
       .alignItems(.center)
-      .marginTop(-50.adjusted)
       .define{ flex in
         flex.addItem(missionImageView)
-          .width(120%)
-          .height(120%)
+          .position(.absolute)
+          .width(100%)
+          .height(100%)
         flex.addItem(todayMissionLabel)
           .position(.absolute)
           .alignSelf(.center)
@@ -269,7 +269,9 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
   }
   
   func configureCell(record: RecordList) {
-    let processor = DownsamplingImageProcessor(size: CGSize(width: 255, height: 255))
+    let recordImageProcessor = DownsamplingImageProcessor(size: CGSize(width: 255, height: 255))
+    let missionImageProcessor = DownsamplingImageProcessor(size: CGSize(width: 255, height: 436))
+    let round = RoundCornerImageProcessor(cornerRadius: 30.adjusted)
     
     self.textView.text = record.recordContent
     self.textView.textColor = Colors.gray600.color
@@ -277,14 +279,15 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
     self.missionImageView.kf.setImage(
       with: URL(string: record.missionIllustrationURL),
       options: [
-        .processor(processor),
+        .processor(missionImageProcessor),
+        .processor(round),
         .scaleFactor(UIScreen.main.scale),
         .cacheOriginalImage
       ])
     self.recordimageView.kf.setImage(
       with: URL(string: record.recordImageURL),
       options: [
-        .processor(processor),
+        .processor(recordImageProcessor),
         .scaleFactor(UIScreen.main.scale),
         .cacheOriginalImage,
         .transition(.fade(0.2))

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
@@ -182,7 +182,6 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
       }
     
     missionInfoContainer.flex
-      .alignItems(.center)
       .define{ flex in
         flex.addItem(missionImageView)
           .position(.absolute)
@@ -191,11 +190,11 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
         flex.addItem(todayMissionLabel)
           .position(.absolute)
           .alignSelf(.center)
-          .top(118.adjusted)
+          .top(68.adjusted)
         flex.addItem(missionTitleLabel)
           .position(.absolute)
           .alignSelf(.center)
-          .top(139.adjusted)
+          .top(89.adjusted)
           .marginHorizontal(20.adjusted)
       }
     


### PR DESCRIPTION
## 📌 개요
- issue: #299 

## ✍️ 변경사항
미션 카드에서 이미지 그림자로 인해 약간 확대했던 레이아웃을 정상화했습니다. 

## 📷 스크린샷
<img src = "https://github.com/user-attachments/assets/ef42db8e-7668-4ffa-acab-90b8bce831dd" width = "375px"/>
<img src = "https://github.com/user-attachments/assets/f9a37a4d-37e0-4e82-be52-f7bf45dde0ef" width = "375px"/>

## 🛠️ **Technical Concerns(기술적 고민)**
