### PR TITLE
탭바 아이템 선택 시 최상단 이동 

### DIFF
--- a/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Reactors/FCMReactorImp.swift
@@ -59,9 +59,7 @@ public final class FCMReactorImp: FCMReactor {
     case let .updateItem(index):
       return .just(.updateItem(index: index))
     case let .doubleTap(index):
-      let scrollObservable = Observable.just(Mutation.scrollToTop(index == 2))
-      let resetTabObservable = Observable.just(Mutation.resetTabEvent)
-      return Observable.concat([scrollObservable, resetTabObservable])
+      return ( index == 2 ? Observable.just(Mutation.scrollToTop) : .empty())
     }
   }
   
@@ -85,10 +83,8 @@ public final class FCMReactorImp: FCMReactor {
       newState.isLastPage = isLast
     case let .isHiddenEdgePage(isHidden):
       newState.isHiddenEdgePage = isHidden
-    case let .scrollToTop(isDoubleTapped):
-      newState.isDoubleTap = isDoubleTapped
-    case .resetTabEvent:
-      newState.isDoubleTap = false
+    case .scrollToTop:
+      newState.tabBarTapped = ()
     }
     return newState
   }

--- a/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Implement/Views/FCMViewImp.swift
@@ -258,13 +258,15 @@ extension FCMViewControllerImp: View {
       }
       .disposed(by: disposeBag)
     
-    reactor.state
-      .map{ $0.isDoubleTap }
-      .distinctUntilChanged()
-      .filter { $0 } // 여기서 true인 값만 거르고
+    reactor.pulse(\.$tabBarTapped)
       .observe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, isTapped in
-        owner.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true) // true인 경우에는 상단 이동
+        guard owner.collectionView.numberOfSections > 0,
+              owner.collectionView.numberOfItems(inSection: 0) > 0 else {
+          return
+        }
+        let lastItemIndex = owner.collectionView.numberOfItems(inSection: 0) - 1
+        owner.collectionView.scrollToItem(at: IndexPath(item: lastItemIndex, section: 0), at: .top, animated: true)
       })
       .disposed(by: disposeBag)
   }

--- a/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
+++ b/WalWal/Features/FCM/FCMPresenter/Interface/Reactors/FCMReactor.swift
@@ -30,18 +30,17 @@ public enum FCMReactorMutation {
   case nextCursor(cursor: String?)
   case isLastPage(Bool)
   case isHiddenEdgePage(Bool)
-  case scrollToTop(Bool)
-  case resetTabEvent
+  case scrollToTop
 }
 
 public struct FCMReactorState {
   public init() { }
   @Pulse public var listData: [FCMSection] = []
   @Pulse public var stopRefreshControl: Bool = false
+  @Pulse public var tabBarTapped: Void? = nil
   public var nextCursor: String? = nil
   public var isLastPage: Bool = false
   public var isHiddenEdgePage: Bool = true
-  public var isDoubleTap: Bool = false
 }
 
 public protocol FCMReactor: Reactor where Action == FCMReactorAction, Mutation == FCMReactorMutation, State == FCMReactorState {

--- a/WalWal/Features/Feed/FeedData/Implement/Endpoint/FeedEndpoint.swift
+++ b/WalWal/Features/Feed/FeedData/Implement/Endpoint/FeedEndpoint.swift
@@ -27,7 +27,7 @@ extension FeedEndpoint {
   var path: String{
     switch self {
     case .fetchFeed(let query):
-      return "/feed"
+      return "/feed/v2"
     case .reports:
       return "/reports"
     case let .fetchSingleFeed(recordId):

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Reactors/FeedReactorImp.swift
@@ -77,9 +77,7 @@ public final class FeedReactorImp: FeedReactor {
     case .checkScrollItem:
       return checkScrollEvent()
     case let .doubleTap(index):
-      let scrollObservable = Observable.just(Mutation.scrollToTop(index == 1))
-      let resetTabObservable = Observable.just(Mutation.resetTabEvent)
-      return Observable.concat([scrollObservable, resetTabObservable])
+      return (index == 1 ? Observable.just(Mutation.scrollToTop) : .empty())
     case let .menuTapped(recordId):
       return .just(.showMenu(recordId: recordId))
     case let .commentTapped(recordId, writerNickname):
@@ -105,10 +103,8 @@ public final class FeedReactorImp: FeedReactor {
       coordinator.startProfile(memberId: memberId, nickName: nickName)
     case let .scrollToFeedItem(id):
       newState.scrollToFeedItem = id
-    case let .scrollToTop(isDoubleTapped):
-      newState.isDoubleTap = isDoubleTapped
-    case .resetTabEvent:
-      newState.isDoubleTap = false
+    case .scrollToTop:
+      newState.tabBarTapped = ()
     case let .showMenu(recordId):
       coordinator.destination.accept(.showFeedMenu(recordId: recordId))
     case let .moveToComment(recordId, writerNickname):

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Views/FeedViewImp.swift
@@ -180,10 +180,7 @@ extension FeedViewControllerImp: View {
       }
       .disposed(by: disposeBag)
     
-    reactor.state
-      .map{ $0.isDoubleTap }
-      .distinctUntilChanged()
-      .filter { $0 }
+    reactor.pulse(\.$tabBarTapped)
       .observe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, isTapped in
         owner.feed.collectionView.scrollToItem(at: IndexPath(item: -1, section: 0), at: .init(rawValue: 0), animated: true)

--- a/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Interface/Reactors/FeedReactor.swift
@@ -35,8 +35,7 @@ public enum FeedReactorMutation {
   case feedLoadEnded(nextCursor: String?, feedData: [WalWalFeedModel])
   case moveToProfile(memberId: Int, nickName: String)
   case scrollToFeedItem(id: Int?)
-  case scrollToTop(Bool)
-  case resetTabEvent
+  case scrollToTop
   case showMenu(recordId: Int)
   case moveToComment(recordId: Int, writerNickname: String)
   case updateFeed(record: WalWalFeedModel?)
@@ -49,10 +48,10 @@ public struct FeedReactorState {
   public var nextCursor: String? = nil
   public var feedFetchEnded: Bool = false
   @Pulse public var scrollToFeedItem: Int? = nil
-  public var isDoubleTap: Bool = false
+  @Pulse public var tabBarTapped: Void? = nil
   public init() {  }
 }
-
+ 
 public protocol FeedReactor: Reactor where Action == FeedReactorAction, Mutation == FeedReactorMutation, State == FeedReactorState {
   
   var coordinator: any FeedCoordinator { get }


### PR DESCRIPTION
## 📌 개요
- issue: #304 

## ✍️ 변경사항
탭바 아이템 선택 시 최상단으로 스크롤되는 로직을 `@Pluse`를 이용하여 리팩토링했습니다. 

## 📷 스크린샷
https://github.com/user-attachments/assets/6a3b4391-bf4d-4e42-b77f-fb2066da7039


## 🛠️ **Technical Concerns(기술적 고민)**
여러번 테스트를 했는데도 알림탭에서만 같은 코드로 했을 때 오류가 발생했습니다 ( 섹션 인지 오류 ) 더 좋은 방법이 있다면 이야기해주세요~!
