### PR TITLE
마이페이지 프로필 조회 오류 수정

### DIFF
--- a/WalWal/Features/MyPage/MyPageDomain/Interface/Model/MemberModel.swift
+++ b/WalWal/Features/MyPage/MyPageDomain/Interface/Model/MemberModel.swift
@@ -26,7 +26,7 @@ public struct MemberModel {
     if let defaultProfile = DefaultProfile(rawValue: global.profileURL) {
       defaultImageName = defaultProfile.rawValue
     } else {
-      GlobalState.shared.imageStore.object(forKey: global.profileURL as NSString)
+      self.profileImage = GlobalState.shared.imageStore.object(forKey: global.profileURL as NSString)
     }
   }
   


### PR DESCRIPTION
## 📌 개요
프로필 이미지 보이지 않는 오류 수정

## ✍️ 변경사항
- 마이페이지 진입 시 프로필 이미지가 보이지 않는 오류 수정
  - 프로퍼티 설정 부분이 누락되어있었음

## 📷 스크린샷
|수정 전|수정 후|
|:-----:|:-----:|
|<img src="https://github.com/user-attachments/assets/4c140f3c-7f26-4a0b-aac9-6593dec355e6" width="280">|<img src="https://github.com/user-attachments/assets/15156b8f-3c37-4b45-a4cc-7e936bbb43f8" width="280">|


## 🛠️ **Technical Concerns(기술적 고민)**
