### PR TITLE
미션 완료 뷰 QA 반영

### DIFF
--- a/WalWal/DesignSystem/Sources/WalWalButton/WalWalButton_Icon/WalWalButton_Icon.swift
+++ b/WalWal/DesignSystem/Sources/WalWalButton/WalWalButton_Icon/WalWalButton_Icon.swift
@@ -115,7 +115,7 @@ public class WalWalButton_Icon: UIControl {
     rootView.flex
       .justifyContent(.center)
       .alignItems(.center)
-      .height(50)
+      .height(50.adjusted)
       .define { flex in
         flex.addItem(subContainer)
           .direction(.row)
@@ -123,7 +123,7 @@ public class WalWalButton_Icon: UIControl {
           .alignItems(.center)
           .define { flex in
             flex.addItem(iconImageView)
-              .size(20)
+              .size(20.adjusted)
               .marginRight(2)
             flex.addItem(titleLabel)
           }

--- a/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
+++ b/WalWal/DesignSystem/Sources/WalWalTabBarViewController/WalWalTabBarViewController.swift
@@ -74,7 +74,7 @@ public final class WalWalTabBarViewController: UITabBarController {
   public func showCustomTabBar() {
     self.tabBar.isHidden = true
     containerView.isHidden = false
-    additionalSafeAreaInsets.bottom = 68
+    additionalSafeAreaInsets.bottom = 78.adjusted
   }
 }
 

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
@@ -13,8 +13,6 @@ import PinLayout
 import Then
 import RxSwift
 import RxCocoa
-
-
 public final class BubbleView: UIView {
   
   private typealias Images = ResourceKitAsset.Images
@@ -24,6 +22,7 @@ public final class BubbleView: UIView {
   // MARK: - UI
   
   private let containerView = UIView()
+  private let contentContainerView = UIView() // 새로운 컨테이너 추가
   private let iconImageView = UIImageView().then {
     $0.image = Images.missionStartIcon.image
   }
@@ -45,10 +44,12 @@ public final class BubbleView: UIView {
   
   public init() {
     super.init(frame: .zero)
-    self.backgroundColor =  Colors.gray150.color
-    bind()
+    self.backgroundColor = Colors.gray150.color
+    
     configureAttribute()
     configureLayout()
+    
+    bind()
   }
   
   required init?(coder: NSCoder) {
@@ -62,9 +63,8 @@ public final class BubbleView: UIView {
     layer.cornerRadius = containerView.bounds.height / 2
     
     containerView.sizeToFit()
-
-    self.flex.layout()
     
+    self.flex.layout()
     containerView.flex.layout()
     
     setTipShape(viewColor: self.backgroundColor ?? .clear, tipWidth: tipWidth, tipHeight: tipHeight)
@@ -73,23 +73,31 @@ public final class BubbleView: UIView {
   // MARK: - Method
   
   override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-    return false 
+    return false
   }
   
   private func configureAttribute() {
     self.addSubview(containerView)
-    containerView.addSubview(iconImageView)
-    containerView.addSubview(titleLabel)
+    containerView.addSubview(contentContainerView) // 새로운 컨테이너를 containerView에 추가
+    contentContainerView.addSubview(iconImageView)
+    contentContainerView.addSubview(titleLabel)
   }
   
   private func configureLayout() {
+    // containerView 레이아웃 설정
     containerView.flex
+      .paddingVertical(8.5.adjusted)
+      .paddingHorizontal(20.adjusted)
+      .alignItems(.center)
+      .justifyContent(.center)
+    
+    // contentContainerView 레이아웃 설정 (수평 정렬)
+    contentContainerView.flex
       .direction(.row)
       .alignItems(.center)
       .justifyContent(.center)
-      .paddingVertical(8.5)
-      .paddingHorizontal(22.adjusted)
     
+    // iconImageView와 titleLabel 레이아웃 설정
     iconImageView.flex
       .marginRight(4.adjusted)
     
@@ -103,8 +111,11 @@ public final class BubbleView: UIView {
       .bind(with: self) { owner, data in
         let (count, completed) = data
         owner.titleLabel.text = completed ? "\(count)번째 미션을 완료했어요!" : "\(count+1)번째 미션을 함께 수행해볼까요?"
+        
         owner.titleLabel.flex.markDirty()
+        owner.contentContainerView.flex.markDirty()
         owner.containerView.flex.markDirty()
+        
         owner.setNeedsLayout()
       }
       .disposed(by: disposeBag)
@@ -129,7 +140,8 @@ public final class BubbleView: UIView {
     
     let shape = CAShapeLayer()
     shape.path = path
-    shape.fillColor = viewColor.cgColor   
+    shape.fillColor = viewColor.cgColor
+    
     if tipView == nil {
       tipView = shape
       self.layer.insertSublayer(shape, at: 0)
@@ -154,7 +166,6 @@ public final class BubbleView: UIView {
     
     self.layer.add(moveAnimation, forKey: "moveUpDown")
   }
-  
   
   func stopFloatingAnimation() {
     self.layer.removeAnimation(forKey: "moveUp")

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/BubbleView.swift
@@ -35,8 +35,8 @@ public final class BubbleView: UIView {
   
   // MARK: - Property
   private var tipView: CAShapeLayer? = nil
-  private var tipWidth: CGFloat = 16
-  private var tipHeight: CGFloat = 16
+  private var tipWidth: CGFloat = 14.adjusted
+  private var tipHeight: CGFloat = 14.adjusted
   public var missionCount = BehaviorRelay<Int>(value: 0)
   public var isCompleted = BehaviorRelay<Bool>(value: false)
   private let disposeBag = DisposeBag()
@@ -60,10 +60,12 @@ public final class BubbleView: UIView {
   override public func layoutSubviews() {
     super.layoutSubviews()
     layer.cornerRadius = containerView.bounds.height / 2
-    containerView.pin
-      .all()
-    containerView.flex
-      .layout()
+    
+    containerView.sizeToFit()
+
+    self.flex.layout()
+    
+    containerView.flex.layout()
     
     setTipShape(viewColor: self.backgroundColor ?? .clear, tipWidth: tipWidth, tipHeight: tipHeight)
   }
@@ -85,14 +87,14 @@ public final class BubbleView: UIView {
       .direction(.row)
       .alignItems(.center)
       .justifyContent(.center)
-      .paddingVertical(9.5)
-      .shrink(1)
+      .paddingVertical(8.5)
+      .paddingHorizontal(22.adjusted)
     
     iconImageView.flex
-      .marginRight(4)
-      .marginLeft(20)
+      .marginRight(4.adjusted)
+    
     titleLabel.flex
-      .marginRight(20)
+      .grow(1)
   }
   
   private func bind() {
@@ -119,7 +121,7 @@ public final class BubbleView: UIView {
     let point2 = CGPoint(x: tipStartX + tipWidth, y: tipStartY - 7.0)
     let point3 = CGPoint(x: tipStartX + tipWidth / 2.0, y: tipStartY + tipHeight - 7.0)
     
-    path.move(to: CGPoint(x: tipStartX, y: tipStartY - 5.0))
+    path.move(to: CGPoint(x: tipStartX, y: tipStartY - 2.0))
     path.addArc(tangent1End: point1, tangent2End: point2, radius: radius)
     path.addArc(tangent1End: point2, tangent2End: point3, radius: radius)
     path.addArc(tangent1End: point3, tangent2End: point1, radius: radius)

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
@@ -88,7 +88,6 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
   /// 미션 정보 보기
   private let todayMissionLabel = CustomLabel(font: Fonts.KR.H7.B).then {
     $0.text = "오늘의 미션"
-    $0.font = Fonts.KR.H7.B
     $0.textColor = Colors.walwalOrange.color
   }
   private let missionTitleLabel = CustomLabel(font: Fonts.KR.H4).then {

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/MissionCompleteView.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/MissionCompleteView.swift
@@ -48,7 +48,7 @@ final class MissionCompleteView: UIView {
   private let missionCompletedLabel = CustomLabel(font: Fonts.KR.H2).then {
     $0.text = "📮 이번 달 함께한 추억이에요!"
     $0.textAlignment = .center
-    $0.font = Fonts.KR.H6.B
+    $0.font = UIFont.systemFont(ofSize: 16.adjusted, weight: .bold)
     $0.textColor = Colors.black.color
     $0.numberOfLines = 2
     $0.textAlignment = .center
@@ -140,7 +140,7 @@ final class MissionCompleteView: UIView {
           .marginTop(0)
           .marginHorizontal(24.adjusted)
         $0.addItem(missionRecordCollectionView)
-          .height(496.adjusted)
+          .height(480.adjusted)
           .grow(1)
           .shrink(1)
       }
@@ -180,7 +180,7 @@ final class CarouselFlowLayout: UICollectionViewFlowLayout {
     
     scrollDirection = .horizontal
     
-    minimumLineSpacing = 30 - (itemSize.width - itemSize.width*0.7)/2
+    minimumLineSpacing = 30.adjusted - (itemSize.width - itemSize.width * (216/255))/2
     
     isInit = true
   }
@@ -202,8 +202,10 @@ final class CarouselFlowLayout: UICollectionViewFlowLayout {
       let maxDis = self.itemSize.width + self.minimumLineSpacing
       let dis = min(abs(collectionViewCenter-center), maxDis)
       
+      let maxScale: CGFloat = 1.0
+      let minScale: CGFloat = 216 / 255
       let ratio = (maxDis - dis)/maxDis
-      let scale = ratio * (1-0.7) + 0.7
+      let scale = ratio * (maxScale - minScale) + minScale
       
       attributes.transform = CGAffineTransform(scaleX: scale, y: scale)
     }

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -33,6 +33,7 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
   private let rootContainer = UIView()
   private let missionContainerWrapper = UIView()
   private let buttonContainerWrapper = UIView()
+  private let bubbleContainerWrapper = UIView()
   
   private let splashContainer = UIView().then {
     $0.backgroundColor = Colors.walwalOrange.color
@@ -111,6 +112,7 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
   
   public override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
+    
     rootContainer.pin
       .all(view.pin.safeArea)
     
@@ -140,10 +142,11 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
           .width(100%)
           .position(.absolute)
           .bottom(30.adjusted)
-        flex.addItem(bubbleContainer)
+        flex.addItem(bubbleContainerWrapper)
+          .width(100%)
+          .height(60.adjusted)
+          .bottom(72.adjusted)
           .position(.absolute)
-          .alignSelf(.center)
-          .bottom(70.adjusted)
       }
     
     missionContainer.flex
@@ -171,10 +174,18 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
           .marginHorizontal(20.adjusted)
       }
     
+    bubbleContainerWrapper.flex
+      .define { flex in
+        flex.addItem(bubbleContainer)
+          .grow(1)
+      }
+    
     bubbleContainer.flex
       .define { flex in
         flex.addItem(missionCountBubbleView)
+          .position(.absolute)
           .alignSelf(.center)
+          .bottom(0)
       }
     
     splashContainer.flex
@@ -239,6 +250,10 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
   private func updateBubbleViewTitle(for status: StatusMessage?) {
     let isCompleted = status == .completed ? true : false
     missionCountBubbleView.isCompleted.accept(isCompleted)
+    
+    bubbleContainer.flex.markDirty()
+    
+    bubbleContainer.flex.layout()
   }
   
   private func showCoachView() {

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -33,7 +33,6 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
   private let rootContainer = UIView()
   private let missionContainerWrapper = UIView()
   private let buttonContainerWrapper = UIView()
-  private let bubbleContainerWrapper = UIView()
   
   private let splashContainer = UIView().then {
     $0.backgroundColor = Colors.walwalOrange.color
@@ -114,6 +113,7 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
     super.viewDidLayoutSubviews()
     rootContainer.pin
       .all(view.pin.safeArea)
+    
     rootContainer.flex
       .layout()
     
@@ -140,10 +140,9 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
           .width(100%)
           .position(.absolute)
           .bottom(30.adjusted)
-        flex.addItem(bubbleContainerWrapper)
-          .width(100%)
-          .height(60.adjusted)
+        flex.addItem(bubbleContainer)
           .position(.absolute)
+          .alignSelf(.center)
           .bottom(70.adjusted)
       }
     
@@ -172,18 +171,10 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
           .marginHorizontal(20.adjusted)
       }
     
-    bubbleContainerWrapper.flex
-      .define { flex in
-        flex.addItem(bubbleContainer)
-          .grow(1)
-      }
-    
     bubbleContainer.flex
       .define { flex in
         flex.addItem(missionCountBubbleView)
-          .position(.absolute)
           .alignSelf(.center)
-          .bottom(0)
       }
     
     splashContainer.flex

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -155,7 +155,7 @@ public final class MissionViewControllerImp<R: MissionReactor>: UIViewController
           .alignSelf(.center)
         flex.addItem(missionCompletedView)
           .position(.absolute)
-          .top(39.adjusted)
+          .top(17.adjusted)
           .width(100%)
           .alignSelf(.center)
       }


### PR DESCRIPTION
## 📌 개요
- issue: #312 

## ✍️ 변경사항
미션 완료 화면 QA 반영했습니다. 
1. 지난 미션 뷰 크기 조정
2. 버블뷰 너비 패딩 20px 적용 및 tip 크기 조정
3. 버튼 높이 조정
4. 탭바 높이 조정 (92 -> 102)
5. 상단 여백 조정

## 📷 스크린샷
| 이전 | 반영 이후 | 미션 시작 전 bubbleView|
|:--:|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/b5306b22-e4a5-4add-a388-3cbbf240f45b" width = "375px"/>|<img src="https://github.com/user-attachments/assets/e120b986-abd1-4e3f-94e3-d32b307fd5b8" width = "375px"/>|<img src="https://github.com/user-attachments/assets/2aa9afa2-1495-49e3-b831-22ad2f502919" width = "375px"/>|



## 🛠️ **Technical Concerns(기술적 고민)**
