### PR TITLE
미션 기록 시 이모지 입력 시 오류 수정

### DIFF
--- a/WalWal/DesignSystem/Sources/UnderlinedTextView/UnderlinedTextView.swift
+++ b/WalWal/DesignSystem/Sources/UnderlinedTextView/UnderlinedTextView.swift
@@ -51,42 +51,6 @@ public class UnderlinedTextView: UITextView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  /// 마지막 엔터 제거하고 키보드 내리기
-  public func endEditingWithDeleteNewLines() {
-    if let selectedRange = selectedTextRange,
-        let curText = text,
-        !curText.isEmpty {
-      let cursorPosition = offset(from: beginningOfDocument, to: selectedRange.start)
-      
-      // 현재 텍스트
-      var text = curText
-      
-      // 커서 위치 바로 앞의 문자 확인
-      let index = text.index(text.startIndex, offsetBy: cursorPosition - 1)
-      if text[index] == "\n" {
-        // 엔터가 입력된 경우, 해당 엔터 제거
-        text.remove(at: index)
-        
-        // attributedText를 유지하면서 텍스트 업데이트
-        let mutableAttributedString = NSMutableAttributedString(attributedString: attributedText)
-        mutableAttributedString.mutableString.deleteCharacters(
-          in: NSRange(
-            location: cursorPosition - 1,
-            length: 1
-          )
-        )
-        
-        attributedText = mutableAttributedString
-        
-        // 커서를 제거된 위치로 다시 설정
-        if let newPosition = position(from: beginningOfDocument, offset: cursorPosition - 1) {
-          selectedTextRange = textRange(from: newPosition, to: newPosition)
-        }
-        endEditing(true)
-      }
-    }
-  }
-  
   /// AttributedText 속성 설정 메서드
   public func configureAttributeText() {
     let paragraphStyle = NSMutableParagraphStyle()

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
@@ -152,7 +152,6 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
     
     recordimageView.addSubview(dateChipView)
     
-    textView.endEditingWithDeleteNewLines()
     textView.configureAttributeText()
   }
   

--- a/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Views/Component/StyledTextInputView.swift
+++ b/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Views/Component/StyledTextInputView.swift
@@ -164,7 +164,6 @@ final class StyledTextInputView: UIView {
     textView.rx.didChange
       .asDriver()
       .drive(with: self) { owner, _ in
-        owner.textView.endEditingWithDeleteNewLines()
         owner.textView.configureAttributeText()
       }
       .disposed(by: disposeBag)
@@ -173,6 +172,9 @@ final class StyledTextInputView: UIView {
     textRelay
       .map { "\($0.count)/80"}
       .bind(to: characterCountLabel.rx.text)
+      .disposed(by: disposeBag)
+    
+    textView.rx.setDelegate(self)
       .disposed(by: disposeBag)
   }
   
@@ -190,7 +192,20 @@ final class StyledTextInputView: UIView {
     textView.text = cutting
   }
   
+}
+
+// MARK: - UITextFieldDelegate
+
+extension StyledTextInputView: UITextViewDelegate {
   
+  /// 엔터 입력 시 입력 종료
+  public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+    if text == "\n" {
+      textView.endEditing(true)
+      return false
+    }
+    return true
+  }
 }
 
 extension String {


### PR DESCRIPTION
## 📌 개요
미션 수행 후 기록 입력 시 이모지 입력하면 런타임 오류 발생
- 기존에 엔터 입력 시 엔터를 포함하지 않고 입력을 끝내기 위해 현재 커서 위치를 통해 인덱스를 찾아 엔터가 입력됐는지 탐색하도록 구현
- 이모지 입력하면 커서의 위치가 이모지를 4칸으로 인식함 -> 인덱스를 찾을 때 문자열을 utf16을 기준으로 크기를 계산하는데 이모지는 크기가 4를 가지고 있음
- 이러한 이유로 기존 코드에서 `Index Out of bounds`오류가 발생했음
기존 코드
```swift
let cursorPosition = offset(from: beginningOfDocument, to: selectedRange.start)

// 커서 위치 바로 앞의 문자 확인
let index = text.index(text.startIndex, offsetBy: cursorPosition - 1)
if text[index] == "\n" { // 이 부분에서 오류 발생
    // 엔터가 입력된 경우, 해당 엔터 제거
    text.remove(at: index)
}
```
## ✍️ 변경사항
- UITextView를 사용하는 곳에서 delegate를 통해 현재 입력되고있는 문자를 체크
- 엔터일 경우 글자를 포함시키지 않고 입력 종료
```swift
extension StyledTextInputView: UITextViewDelegate {

  /// 엔터 입력 시 입력 종료
  public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
    if text == "\n" {
      textView.endEditing(true)
      return false
    }
    return true
  }
}
```

## 📷 스크린샷
- 이모지 입력하는 화면을 녹화하려 했으나 이미 기회를 다 써버림 이슈..
<img src = "https://github.com/user-attachments/assets/d8b0dd6b-ddc0-4a02-a00a-5137bb94bffe" width="300">



## 🛠️ **Technical Concerns(기술적 고민)**
