### PR TITLE
댓글페이지에서 유저 프로필 이동 기능 구현

### DIFF
--- a/WalWal/Coordinators/Comment/CommentCoordinator/Implement/CommentCoordinatorImp.swift
+++ b/WalWal/Coordinators/Comment/CommentCoordinator/Implement/CommentCoordinatorImp.swift
@@ -112,4 +112,11 @@ extension CommentCoordinatorImp {
       self?.requireFromChild.onNext(.requireParentAction(.dismissComment(recordId)))
     }
   }
+  
+  public func moveToWriterPage(_ writerId: Int, _ nickname: String) {
+    print("작성자 페이지로 이동, 부모 이밴트 요청")
+    self.dismissViewController { [weak self] in
+      self?.requireFromChild.onNext(.requireParentAction(.moveToWriterPage(writerId, nickname)))
+    }
+  }
 }

--- a/WalWal/Coordinators/Comment/CommentCoordinator/Interface/CommentCoordinator.swift
+++ b/WalWal/Coordinators/Comment/CommentCoordinator/Interface/CommentCoordinator.swift
@@ -11,6 +11,7 @@ import BaseCoordinator
 
 public enum CommentCoordinatorAction: ParentAction {
   case dismissComment(Int)
+  case moveToWriterPage(Int, String)
 }
 
 public enum CommentCoordinatorFlow: CoordinatorFlow {
@@ -21,4 +22,5 @@ public protocol CommentCoordinator: BaseCoordinator
 where Flow == CommentCoordinatorFlow,
       Action == CommentCoordinatorAction {
   func reloadFeedAt(_ recordId: Int)
+  func moveToWriterPage(_ writerId: Int, _ nickmame: String)
 }

--- a/WalWal/Coordinators/Feed/FeedCoordinator/Implement/FeedCoordinatorImp.swift
+++ b/WalWal/Coordinators/Feed/FeedCoordinator/Implement/FeedCoordinatorImp.swift
@@ -132,6 +132,9 @@ extension FeedCoordinatorImp {
       case .dismissComment(let recordId):
         self.childCoordinator = nil
         self.baseReactor?.action.onNext(.refreshFeedData(recordId: recordId))
+      case let .moveToWriterPage(writerId, nickname):
+        self.childCoordinator = nil
+        startProfile(memberId: writerId, nickName: nickname)
       }
     }
   }

--- a/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
+++ b/WalWal/Coordinators/MyPage/MyPageCoordinator/Implement/MyPageCoordinatorImp.swift
@@ -186,6 +186,7 @@ extension MyPageCoordinatorImp {
       case .dismissComment(let recordId):
         self.childCoordinator = nil
         self.baseReactor?.action.onNext(.refreshFeedData(recordId: recordId))
+      case .moveToWriterPage(_, _): return /// 그냥 댓글에서 넘어 온 케이스는, 추가 동작 따로 없는걸루
       }
     }
   }

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Reactors/CommentReactorImp.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Reactors/CommentReactorImp.swift
@@ -77,6 +77,8 @@ public final class CommentReactorImp: CommentReactor {
       return Observable.just(.dismissSheet)
     case let .setReplyMode(isReply, parentId):
       return Observable.just(.setReplyMode(parentId, isReply))
+    case let .setWriter(writerId, nickname):
+      return dismissAndMoveWriter(writerId: writerId, nickname: nickname)
     case .resetParentId:
       return Observable.just(.setReplyMode(nil, false))
     case .resetFocusing:
@@ -91,8 +93,13 @@ public final class CommentReactorImp: CommentReactor {
       newState.comments = comments
       newState.isReply = false // 한번 보내면 대댓글 상태 초기화 하자
       newState.parentId = nil // 한번 보내면 parentID도 초기화
+    case let .dismissAndMoveWriter(writerId, nickname):
+      newState.isSheetDismissed = true
+      coordinator.moveToWriterPage(writerId, nickname)
     case let .setSheetPosition(position):
       newState.sheetPosition = position
+    case let .showToast(toastMessage):
+      newState.toastMessage = toastMessage
     case .dismissSheet:
       coordinator.reloadFeedAt(recordId)
     case let .setReplyMode(parentId, isReply):
@@ -100,6 +107,8 @@ public final class CommentReactorImp: CommentReactor {
       newState.isReply = isReply
     case let .isNeedFocusing(isNeed):
       newState.isNeedFocusing = isNeed
+    case let .setLoading(isLoading):
+      newState.isLoading = isLoading
     }
     return newState
     
@@ -107,6 +116,17 @@ public final class CommentReactorImp: CommentReactor {
 }
 
 extension CommentReactorImp {
+  
+  private func dismissAndMoveWriter(writerId: Int?, nickname: String) -> Observable<Mutation> {
+    if let writerId = writerId {
+      return .concat([
+        .just(.setLoading(isLoading: true)),
+        .just(.dismissAndMoveWriter(writerId, nickname))
+      ])
+    } else {
+      return .just(.showToast(message: "탈퇴한 회원의 프로필이에요"))
+    }
+  }
   
   /// 댓글 리스트 가져오기
   private func fetchCommentData() -> Observable<Mutation> {

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Views/Cells/CommentCell.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Views/Cells/CommentCell.swift
@@ -41,7 +41,7 @@ final class CommentCell: UITableViewCell, ReusableView {
   public var disposeBag = DisposeBag()
   public var parentIdGetted = BehaviorRelay<Int?>(value: nil)
   
-  private let profileImageView = UIImageView().then {
+  public let profileImageView = UIImageView().then {
     $0.contentMode = .scaleAspectFill
     $0.backgroundColor = AssetColor.gray200.color
     $0.layer.cornerRadius = 17

--- a/WalWal/Features/Comment/CommentPresenter/Implement/Views/Cells/ReplyCommentCell.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Implement/Views/Cells/ReplyCommentCell.swift
@@ -14,11 +14,14 @@ import CommentDomain
 import Then
 import FlexLayout
 import PinLayout
+import RxSwift
 
 final class ReplyCommentCell: UITableViewCell, ReusableView {
   
   private typealias FontKR = ResourceKitFontFamily.KR
   private typealias AssetColor = ResourceKitAsset.Colors
+  
+  public var disposeBag = DisposeBag()
   
   // 컨테이너 뷰 추가
   private let rootContainerView = UIView()
@@ -32,7 +35,7 @@ final class ReplyCommentCell: UITableViewCell, ReusableView {
   private let timeLabelContainer = UIView()
   private let contentLabelContainer = UIView()
   
-  private let profileImageView = UIImageView().then {
+  public let profileImageView = UIImageView().then {
     $0.contentMode = .scaleAspectFill
     $0.backgroundColor = AssetColor.gray200.color
     $0.layer.cornerRadius = 17
@@ -55,6 +58,7 @@ final class ReplyCommentCell: UITableViewCell, ReusableView {
     $0.textColor = AssetColor.black.color
     $0.numberOfLines = 0
   }
+  
   
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/WalWal/Features/Comment/CommentPresenter/Interface/Reactors/CommentReactor.swift
+++ b/WalWal/Features/Comment/CommentPresenter/Interface/Reactors/CommentReactor.swift
@@ -23,14 +23,18 @@ public enum CommentReactorAction {
   case setReplyMode(isReply: Bool, parentId: Int?) /// 대댓글 모드 설정 액션
   case resetParentId /// 대댓글 모드 해제 액션
   case resetFocusing
+  case setWriter(writerId: Int?, nickname: String)
 }
 
 
 public enum CommentReactorMutation {
+  case setLoading(isLoading: Bool)
   case setComments([FlattenCommentModel]) /// 댓글 데이터를 설정하는 Mutation
   case setReplyMode(Int?, Bool)
+  case dismissAndMoveWriter(Int, String)
   // 바텀 시트 관련 Mutation
   case setSheetPosition(CGFloat)
+  case showToast(message: String)
   case dismissSheet
   case isNeedFocusing(Bool)
 }
@@ -43,10 +47,12 @@ public struct CommentReactorState {
   public var isLoading: Bool = false
   public var sheetPosition: CGFloat = 0
   public var isSheetDismissed: Bool = false
+  public var writerId: Int?
   public let recordId: Int
   public let writerNickname: String
   public var focusCommentId: Int?
   public var isNeedFocusing: Bool = false
+  @Pulse public var toastMessage: String? = nil
   
   public init(
     recordId: Int,


### PR DESCRIPTION
## 📌 개요
- issue: #328 
댓글 페이지에서, 프로필 이미지를 통핸 유저페이지 이동 기능을 구현합니다.
## ✍️ 변경사항
- 댓글 / 대댓글 유저 프로필 선택 시, 해당 유저 페이지로 이동
- 탈퇴한 유저의 경우 토스트 알림 등장
- 페이지 전환 시, 인디케이터 노출을 통한 UX 강화
## 📷 스크린샷

https://github.com/user-attachments/assets/d83de27f-dde9-480d-8c12-3625f991d5ac


## 🛠️ **Technical Concerns(기술적 고민)**
