### PR TITLE
Alert 동작 관련 수정

### DIFF
--- a/WalWal/DesignSystem/DemoApp/Sources/WalWalAlert/WalWalAlertViewController.swift
+++ b/WalWal/DesignSystem/DemoApp/Sources/WalWalAlert/WalWalAlertViewController.swift
@@ -21,25 +21,18 @@ public final class WalWalAlertViewController: UIViewController {
   
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    WalWalAlert.shared.show(
-      title: "회원 탈퇴",
-      bodyMessage: "회원 탈퇴 시, 계정은 삭제되며 기록된 내용은 복구되지 않습니다.",
-      cancelTitle: "계속 이용하기",
-      okTitle: "회원 탈퇴"
-    )
+    Observable.just(AlertEventType.deleteMissionRecord)
+      .bind(to: WalWalAlert.shared.rx.showAlert)
+      .disposed(by: disposeBag)
   }
   
   private func bind() {
-    WalWalAlert.shared.resultRelay
-      .bind(with: self) { owner, result in
+    WalWalAlert.shared.rx.okEvent
+      .subscribe(onNext: { result in
         switch result {
-        case .cancel:
-          print("cancel")
-          WalWalAlert.shared.closeAlert.accept(())
-        case .ok:
-          print("ok")
+        default: print("이벤트 타입: \(result.self)")
         }
-      }
+      })
       .disposed(by: disposeBag)
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
+++ b/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
@@ -230,8 +230,8 @@ public extension Reactive where Base: WalWalAlert {
     }
   }
   
-  var okEvent: PublishSubject<AlertEventType> {
-    return base.eventSubject
+  var okEvent: Observable<AlertEventType> {
+    return base.eventSubject.asObservable()
   }
 }
 

--- a/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
+++ b/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
@@ -35,14 +35,14 @@ public final class WalWalAlert: NSObject {
   ///
   /// ### 사용 예시
   /// ```swift
-  /// WalWalAlert.shared.resultRelay
-  ///  .filter { $0 == `이벤트 타입` }
-  ///  .bind(with: self) { owner, result in
-  ///    print("이벤트 타입: \(result.rawValue)")
-  ///  }
+  /// WalWalAlert.shared.rx.event
+  ///   .filter { $0 == .updateRequest }
+  ///   .map { _ in Reactor.Action.moveUpdate }
+  ///   .bind(to: reactor.action)
+  ///   .disposed(by: disposeBag)
   /// ```
   /// - Returns: `AlertEventType` 타입의 이벤트 -> 사용자 정의 이벤트
-  fileprivate let eventRelay = PublishRelay<AlertEventType>()
+  fileprivate let eventSubject = PublishSubject<AlertEventType>()
   
   private var isOneButtonAlert: Bool = false
   private var closeButtonMargin: CGFloat = 8
@@ -233,7 +233,7 @@ public extension Reactive where Base: WalWalAlert {
     }
   }
   
-  var event: ControlEvent<AlertEventType> {
-    return ControlEvent(events: base.eventRelay.asObservable())
+  var event: PublishSubject<AlertEventType> {
+    return base.eventSubject
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
+++ b/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
@@ -32,37 +32,20 @@ public final class WalWalAlert {
   /// 얼럿 버튼 탭 시 어떤 버튼이 눌렸는지에 대한 값을 리턴
   ///
   /// ### 사용 예시
-  /// - show()
   /// ```swift
   /// WalWalAlert.shared.resultRelay
   ///  .bind(with: self) { owner, result in
   ///    switch result {
   ///    case .cancel:
   ///      print("cancel")
-  ///      WalWalAlert.shared.closeAlert.accept(())
   ///    case .ok:
   ///      print("ok")
-  ///      WalWalAlert.shared.closeAlert.accept(())
   ///    }
   ///  }
-  ///  .disposed(by: disposeBag)
-  /// ```
-  /// 또는
-  /// - showOKAlert()
-  /// ```swift
-  /// WalWalAlert.shared.resultRelay
-  ///   .map { _ in Void() }
-  ///   .bind(to: WalWalAlert.shared.closeAlert)
-  ///   .disposed(by: disposeBag)
   /// ```
   /// - Returns: .cancel 또는 .ok
   public let resultRelay = PublishRelay<AlertResultType>()
   
-  /// 얼럿 화면을 닫기 위한 이벤트
-  ///
-  /// ### 사용 예시
-  /// `WalWalAlert.shared.closeAlert.accept(())`
-  public let closeAlert = PublishRelay<Void>()
   private var isOneButtonAlert: Bool = false
   private var closeButtonMargin: CGFloat = 8
   
@@ -222,20 +205,21 @@ public final class WalWalAlert {
   }
   
   private func bind() {
-    Observable.merge(
-      cancelButton.rx.tapped
-        .map { AlertResultType.cancel},
-      okButton.rx.tapped
-        .map { AlertResultType.ok}
-    )
-    .bind(to: resultRelay)
-    .disposed(by: disposeBag)
     
-    closeAlert
+    cancelButton.rx.tapped
       .bind(with: self) { owner, _ in
+        owner.resultRelay.accept(.cancel)
         owner.rootContainer.removeFromSuperview()
       }
       .disposed(by: disposeBag)
+    
+    okButton.rx.tapped
+      .bind(with: self) { owner, _ in
+        owner.resultRelay.accept(.ok)
+        owner.rootContainer.removeFromSuperview()
+      }
+      .disposed(by: disposeBag)
+    
   }
   
   private func initLayout() {

--- a/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
+++ b/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
@@ -230,7 +230,7 @@ public extension Reactive where Base: WalWalAlert {
     }
   }
   
-  var event: PublishSubject<AlertEventType> {
+  var okEvent: PublishSubject<AlertEventType> {
     return base.eventSubject
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
+++ b/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
@@ -67,7 +67,7 @@ public final class WalWalAlert: NSObject {
     $0.numberOfLines = 0
     $0.textAlignment = .center
   }
-  private let cancelButton =  WalWalButton(
+  private let cancelButton = WalWalButton(
     type: .custom(
       backgroundColor: Colors.walwalOrange.color,
       titleColor: Colors.white.color,
@@ -76,8 +76,8 @@ public final class WalWalAlert: NSObject {
   )
   private let okButton = WalWalButton(
     type: .custom(
-      backgroundColor: Colors.white.color,
-      titleColor: Colors.gray500.color,
+      backgroundColor: Colors.walwalOrange.color,
+      titleColor: Colors.white.color,
       font: FontsKR.H6.B, isEnable: true),
     title: ""
   )
@@ -104,7 +104,13 @@ public final class WalWalAlert: NSObject {
     bodyLabel.text = eventType.contents.bodyMessage
     cancelButton.title = eventType.contents.cancelTitle
     okButton.title = eventType.contents.okTitle
-    cancelButton.backgroundColor = eventType.contents.tintColor ?? Colors.walwalOrange.color
+    
+    cancelButton.backgroundColor = eventType.alertColorSet.cancelColorSet.backgroundColor
+    cancelButton.titleColor = eventType.alertColorSet.cancelColorSet.textColor
+    
+    okButton.backgroundColor = eventType.alertColorSet.okColorSet.backgroundColor
+    okButton.titleColor = eventType.alertColorSet.okColorSet.textColor
+    
     isOneButtonAlert = false
     
     currentEventType = eventType
@@ -112,7 +118,7 @@ public final class WalWalAlert: NSObject {
     guard let window = UIWindow.key else { return }
     window.addSubview(rootContainer)
     configureLayout()
-    okButton.isHidden = false
+    cancelButton.isHidden = false
   }
   
   /// 얼럿 뷰를 보여주기 위한 메서드
@@ -134,23 +140,29 @@ public final class WalWalAlert: NSObject {
   ) {
     titleLabel.text = eventType.contents.title
     bodyLabel.text = eventType.contents.bodyMessage
-    cancelButton.title = eventType.contents.okTitle
+    okButton.title = eventType.contents.okTitle
+    
+    cancelButton.backgroundColor = eventType.alertColorSet.cancelColorSet.backgroundColor
+    cancelButton.titleColor = eventType.alertColorSet.cancelColorSet.textColor
+    
+    okButton.backgroundColor = eventType.alertColorSet.okColorSet.backgroundColor
+    okButton.titleColor = eventType.alertColorSet.okColorSet.textColor
+    
     isOneButtonAlert = true
-    cancelButton.backgroundColor = eventType.contents.tintColor ?? Colors.walwalOrange.color
     
     currentEventType = eventType
     
     guard let window = UIWindow.key else { return }
     window.addSubview(rootContainer)
     configureLayout()
-    okButton.isHidden = true
+    cancelButton.isHidden = true
   }
   
   private func configureLayout() {
     
     initLayout()
     closeButtonMargin = isOneButtonAlert ? 20 : 8
-    okButton.flex.isIncludedInLayout = !isOneButtonAlert
+    cancelButton.flex.isIncludedInLayout = !isOneButtonAlert
     
     rootContainer.addSubview(alertView)
     
@@ -172,9 +184,9 @@ public final class WalWalAlert: NSObject {
           .height(56.adjustedHeight)
           .marginTop(30.adjustedHeight)
           .marginHorizontal(20.adjustedWidth)
-          .marginBottom(closeButtonMargin)
         $0.addItem(okButton)
           .height(56.adjustedHeight)
+          .marginTop(closeButtonMargin)
           .marginBottom(20.adjustedWidth)
           .marginHorizontal(20.adjustedWidth)
       }
@@ -246,8 +258,10 @@ public enum AlertEventType {
   case report
   /// 미션 기록 삭제 이벤트
   case deleteMissionRecord
+  /// 회원 탈퇴 이벤트
+  case withdraw
   
-  var contents: (title: String, bodyMessage: String, cancelTitle: String?, okTitle: String, tintColor: UIColor?) {
+  var contents: (title: String, bodyMessage: String, cancelTitle: String?, okTitle: String, tintColor: AlertColorSet) {
     switch self {
     case .updateRequest:
       return (
@@ -255,7 +269,7 @@ public enum AlertEventType {
         bodyMessage: "왈왈에서 더 재밌게 소통할 수 있도록\n신규 기능을 업데이트 해보세요!",
         cancelTitle: nil,
         okTitle: "업데이트",
-        tintColor: ResourceKitAsset.Colors.walwalOrange.color
+        tintColor: self.alertColorSet
       )
     case .grantedCameraAccess:
       return (
@@ -263,7 +277,7 @@ public enum AlertEventType {
         bodyMessage: "설정 > 왈왈 탭에서 접근을 활성화 할 수 있습니다.",
         cancelTitle: nil,
         okTitle: "확인",
-        tintColor: ResourceKitAsset.Colors.walwalOrange.color
+        tintColor: self.alertColorSet
       )
     case .grantedPhotoLibraryAccess:
       return (
@@ -271,7 +285,7 @@ public enum AlertEventType {
         bodyMessage: "설정 > 왈왈 탭에서 접근을 활성화 할 수 있습니다.",
         cancelTitle: nil,
         okTitle: "확인",
-        tintColor: ResourceKitAsset.Colors.walwalOrange.color
+        tintColor: self.alertColorSet
       )
     case .report:
       return (
@@ -279,7 +293,7 @@ public enum AlertEventType {
         bodyMessage: "더 귀여운 왈왈을 위해 열심히 노력할게요?",
         cancelTitle: nil,
         okTitle: "완료",
-        tintColor: ResourceKitAsset.Colors.black.color
+        tintColor: self.alertColorSet
         )
     case .deleteMissionRecord:
       return (
@@ -287,8 +301,62 @@ public enum AlertEventType {
         bodyMessage: "지금 돌아가면 입력하신 내용이 모두\n삭제됩니다.",
         cancelTitle: "계속 작성하기",
         okTitle: "삭제하기",
-        tintColor: ResourceKitAsset.Colors.walwalOrange.color
+        tintColor: self.alertColorSet
+        )
+    case .withdraw:
+      return (
+        title: "회원 탈퇴",
+        bodyMessage: "회원 탈퇴 시, 계정은 삭제되며 기록된 내용은\n복구되지 않습니다.",
+        cancelTitle: "계속 이용하기",
+        okTitle: "회원 탈퇴",
+        tintColor: self.alertColorSet
         )
     }
+  }
+  
+  var alertColorSet: AlertColorSet {
+    let orange = ResourceKitAsset.Colors.walwalOrange.color
+    let white = ResourceKitAsset.Colors.white.color
+    
+    let black = ResourceKitAsset.Colors.black.color
+    let gray = ResourceKitAsset.Colors.gray500.color
+    
+    switch self {
+    case .updateRequest:
+      return AlertColorSet(
+        cancelColorSet: (backgroundColor: nil, textColor: nil),
+        okColorSet: (backgroundColor: orange, textColor: white)
+      )
+    case .grantedCameraAccess:
+      return AlertColorSet(
+        cancelColorSet: (backgroundColor: nil, textColor: nil),
+        okColorSet: (backgroundColor: orange, textColor: white)
+      )
+    case .grantedPhotoLibraryAccess:
+      return AlertColorSet(
+        cancelColorSet: (backgroundColor: nil, textColor: nil),
+        okColorSet: (backgroundColor: orange, textColor: white)
+      )
+    case .report:
+      return AlertColorSet(
+        cancelColorSet: (backgroundColor: nil, textColor: nil),
+        okColorSet: (backgroundColor: black, textColor: white)
+      )
+    case .deleteMissionRecord:
+      return AlertColorSet(
+        cancelColorSet: (backgroundColor: orange, textColor: white),
+        okColorSet: (backgroundColor: white, textColor: gray)
+      )
+    case .withdraw:
+      return AlertColorSet(
+        cancelColorSet: (backgroundColor: orange, textColor: white),
+        okColorSet: (backgroundColor: white, textColor: gray)
+      )
+    }
+  }
+  
+  struct AlertColorSet {
+    var cancelColorSet: (backgroundColor: UIColor?, textColor: UIColor?)
+    var okColorSet: (backgroundColor: UIColor?, textColor: UIColor?)
   }
 }

--- a/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
+++ b/WalWal/DesignSystem/Sources/WalWalAlert/WalWalAlert.swift
@@ -226,13 +226,10 @@ public final class WalWalAlert: NSObject {
 public extension Reactive where Base: WalWalAlert {
   var showAlert: Binder<(String, String, String, String?)> {
     return Binder(self.base) { owner, value in
-      owner.show(title: value.0, bodyMessage: value.1, cancelTitle: value.2, okTitle: value.3)
-    }
-  }
-  
-  var showOkAlert: Binder<(String, String, String)> {
-    return Binder(self.base) { owner, value in
-      owner.showOkAlert(title: value.0, bodyMessage: value.1, okTitle: value.2)
+      guard let okTitle = value.3 else {
+        return owner.showOkAlert(title: value.0, bodyMessage: value.1, okTitle: value.2)
+      }
+      return owner.show(title: value.0, bodyMessage: value.1, cancelTitle: value.2, okTitle: okTitle)
     }
   }
   

--- a/WalWal/DesignSystem/Sources/WalWalButton/WalWalButton/WalWalButton.swift
+++ b/WalWal/DesignSystem/Sources/WalWalButton/WalWalButton/WalWalButton.swift
@@ -35,7 +35,7 @@ public class WalWalButton: UIControl {
   
   private let rootView = UIView()
   
-  private lazy var titleLabel = UILabel().then {
+  fileprivate lazy var titleLabel = UILabel().then {
     $0.textAlignment = .center
     $0.font = Fonts.KR.H5.B
     $0.text = title
@@ -46,6 +46,12 @@ public class WalWalButton: UIControl {
   public var title: String? {
     didSet {
       titleLabel.text = title
+    }
+  }
+  
+  public var titleColor: UIColor? {
+    didSet {
+      titleLabel.textColor = titleColor ?? Colors.white.color
     }
   }
   

--- a/WalWal/Features/Feed/FeedPresenter/Implement/Views/ReportView/ReportDetailViewImp.swift
+++ b/WalWal/Features/Feed/FeedPresenter/Implement/Views/ReportView/ReportDetailViewImp.swift
@@ -380,16 +380,9 @@ extension ReportDetailViewControllerImp: View {
     reactor.state
       .map { $0.showAlert }
       .distinctUntilChanged()
-      .asDriver(onErrorJustReturn: false)
       .filter { $0 }
-      .drive(with: self) { owner, _ in
-        WalWalAlert.shared.showOkAlert(
-          title: "소중한 정보 고마워요!",
-          bodyMessage: "더 귀여운 왈왈을 위해 열심히 노력할게요",
-          okTitle: "완료",
-          tintColor: Colors.black.color
-        )
-      }
+      .map { _ in AlertEventType.report }
+      .bind(to: WalWalAlert.shared.rx.showAlert)
       .disposed(by: disposeBag)
     
     reactor.state
@@ -470,9 +463,8 @@ extension ReportDetailViewControllerImp: View {
       }
       .disposed(by: disposeBag)
     
-    /// 제출 완료 얼럿 닫은 후 dismiss 액션 수행
-    WalWalAlert.shared.resultRelay
-      .map { _ in Void() }
+    WalWalAlert.shared.rx.okEvent
+      .filter { $0 == .report }
       .bind(with: self) { owner, _ in
         owner.dismissView.accept(())
       }

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionSelectViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionSelectViewImp.swift
@@ -227,33 +227,17 @@ extension MissionSelectViewControllerImp: View {
       .disposed(by: disposeBag)
     
     reactor.pulse(\.$isGrantedPhoto)
-      .observe(on: MainScheduler.instance)
-      .asDriver(onErrorJustReturn: false)
       .skip(1)
-      .drive(with: self) { owner, isAllowed in
-        if !isAllowed {
-          WalWalAlert.shared.showOkAlert(
-            title: "앨범에 대한 접근 권한이 없습니다",
-            bodyMessage: "설정 > 왈왈 탭에서 접근을 활성화 할 수 있습니다.",
-            okTitle: "확인"
-          )
-        }
-      }
+      .filter { !$0 }
+      .map { _ in AlertEventType.grantedPhotoLibraryAccess }
+      .bind(to: WalWalAlert.shared.rx.showAlert)
       .disposed(by: disposeBag)
     
     reactor.pulse(\.$isGrantedCamera)
-      .observe(on: MainScheduler.instance)
-      .asDriver(onErrorJustReturn: false)
       .skip(1)
-      .drive(with: self) { owner, isAllowed in
-        if !isAllowed {
-          WalWalAlert.shared.showOkAlert(
-            title: "카메라에 대한 접근 권한이 없습니다",
-            bodyMessage: "설정 > 왈왈 탭에서 접근을 활성화 할 수 있습니다.",
-            okTitle: "확인"
-          )
-        }
-      }
+      .filter { !$0 }
+      .map { _ in AlertEventType.grantedCameraAccess }
+      .bind(to: WalWalAlert.shared.rx.showAlert)
       .disposed(by: disposeBag)
   }
   

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/MissionViewImp.swift
@@ -444,12 +444,5 @@ extension MissionViewControllerImp: View {
     
   }
   
-  public func bindEvent() {
-    WalWalAlert.shared.resultRelay
-      .map { _ in Void() }
-      .observe(on: MainScheduler.instance)
-      .bind(to: WalWalAlert.shared.closeAlert)
-      .disposed(by: disposeBag)
-    
-  }
+  public func bindEvent() { }
 }

--- a/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Reactors/WriteContentDuringTheMissionReactorImp.swift
+++ b/WalWal/Features/MissionUpload/MissionUploadPresenter/Implement/Reactors/WriteContentDuringTheMissionReactorImp.swift
@@ -52,15 +52,8 @@ public final class WriteContentDuringTheMissionReactorImp: WriteContentDuringThe
   
   public func mutate(action: Action) -> Observable<Mutation> {
     switch action {
-    case .backButtonTapped: /// 뒤로가기 버튼을 눌렀어
-      return .just(Mutation.showMeTheAlert(show: true))
-    case .deleteThisContent: /// 얼럿에서 삭제하기 눌렀어
-      return .concat([
-        .just(Mutation.showMeTheAlert(show: false)),
-        .just(Mutation.moveToMain)
-      ])
-    case .keepThisContent: /// 얼럿에서 취소하기 눌렀어
-      return .just(Mutation.showMeTheAlert(show: false))
+    case .deleteThisContent:
+      return .just(Mutation.moveToMain)
     case .uploadButtonTapped(let image, let content): /// 피드 공유하기 버튼 눌렀어
       return .concat([
         .just(Mutation.showLottie(show: true)),
@@ -72,8 +65,6 @@ public final class WriteContentDuringTheMissionReactorImp: WriteContentDuringThe
   public func reduce(state: State, mutation: Mutation) -> State {
     var newState = state
     switch mutation {
-    case .showMeTheAlert(let isShow):
-      newState.isAlertWillPresent = isShow
     case let .showLottie(show):
       newState.showLottie = show
     case .uploadFailed(message: let message):

--- a/WalWal/Features/MissionUpload/MissionUploadPresenter/Interface/Reactors/WriteContentDuringTheMissionReactor.swift
+++ b/WalWal/Features/MissionUpload/MissionUploadPresenter/Interface/Reactors/WriteContentDuringTheMissionReactor.swift
@@ -17,14 +17,11 @@ import ReactorKit
 import RxSwift
 
 public enum WriteContentDuringTheMissionReactorAction {
-  case backButtonTapped
   case uploadButtonTapped(capturedImage: UIImage, content: String)
   case deleteThisContent
-  case keepThisContent
 }
 
 public enum WriteContentDuringTheMissionReactorMutation {
-  case showMeTheAlert(show: Bool) /// 뒤로가기 버튼을 누르고, 얼럿을 띄우고 지우기 (isAlertWillPresent)
   case uploadProcessEnded /// 업로드 프로세스가 끝났어요~
   case uploadFailed(message: String)
   case moveToMain /// 미션으로 돌아가자~
@@ -32,7 +29,6 @@ public enum WriteContentDuringTheMissionReactorMutation {
 }
 
 public struct WriteContentDuringTheMissionReactorState {
-  public var isAlertWillPresent: Bool = false
   @Pulse public var uploadErrorMessage: String = ""
   public var showLottie: Bool = false
   

--- a/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
+++ b/WalWal/Features/MyPage/MyPagePresenter/Implement/Views/ProfileSettingViewImp.swift
@@ -181,29 +181,18 @@ extension ProfileSettingViewControllerImp: View {
   public func bindEvent() {
     settingTableView.rx.modelSelected(ProfileSettingItemModel.self)
       .bind(with: self) { owner, item in
-        if item.type == .withdraw {
-          WalWalAlert.shared.show(
-            title: "회원 탈퇴",
-            bodyMessage: "회원 탈퇴 시, 계정은 삭제되며 기록된 내용은\n복구되지 않습니다.",
-            cancelTitle: "계속 이용하기",
-            okTitle: "회원 탈퇴"
-          )
-        } else {
-          owner.settingAction.accept(item.type)
+        switch item.type {
+        case .withdraw:
+          WalWalAlert.shared.rx.showAlert.onNext(AlertEventType.withdraw)
+        default: owner.settingAction.accept(item.type)
         }
       }
       .disposed(by: disposeBag)
     
-    WalWalAlert.shared.resultRelay
-      .bind(with: self) { owner, result in
-        switch result {
-        case .cancel:
-          WalWalAlert.shared.closeAlert.accept(())
-        case .ok:
-          owner.withdrawAction.accept(())
-          WalWalAlert.shared.closeAlert.accept(())
-        }
-      }
+    WalWalAlert.shared.rx.okEvent
+      .filter { $0 == .withdraw }
+      .map { _ in }
+      .bind(to: withdrawAction)
       .disposed(by: disposeBag)
   }
 }

--- a/WalWal/Features/Splash/SplashPresenter/Implement/Views/SplashViewImp.swift
+++ b/WalWal/Features/Splash/SplashPresenter/Implement/Views/SplashViewImp.swift
@@ -110,17 +110,12 @@ extension SplashViewControllerImp: View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
-    Observable.combineLatest(
-      WalWalAlert.shared.resultRelay,
-      AppUpdateManager.shared.updateRequest
-    )
-    .map { $0.1 }
-    .distinctUntilChanged()
-    .filter { $0 }
-    .map { _ in Reactor.Action.moveUpdate }
-    .bind(to: reactor.action)
-    .disposed(by: disposeBag)
-      
+    WalWalAlert.shared.rx.okEvent
+      .debug()
+      .filter { $0 == .updateRequest }
+      .map { _ in Reactor.Action.moveUpdate }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
   }
   
   public func bindState(reactor: R) {
@@ -136,21 +131,9 @@ extension SplashViewControllerImp: View {
   
   public func bindEvent() {
     AppUpdateManager.shared.updateRequest
-      .bind(with: self) { owner, _ in
-        owner.showAlert()
-      }
+      .map { AlertEventType.updateRequest }
+      .bind(to: WalWalAlert.shared.rx.showAlert)
       .disposed(by: disposeBag)
   }
   
-  private func showAlert() {
-    let title = "신규 기능 업데이트"
-    let message = "왈왈에서 더 재밌게 소통할 수 있도록\n신규 기능을 업데이트 해보세요!"
-    let buttonTitle = "업데이트"
-    
-    WalWalAlert.shared.showOkAlert(
-      title: title,
-      bodyMessage: message,
-      okTitle: buttonTitle
-    )
-  }
 }

--- a/WalWal/Features/Splash/SplashPresenter/Implement/Views/SplashViewImp.swift
+++ b/WalWal/Features/Splash/SplashPresenter/Implement/Views/SplashViewImp.swift
@@ -111,7 +111,6 @@ extension SplashViewControllerImp: View {
       .disposed(by: disposeBag)
     
     WalWalAlert.shared.rx.okEvent
-      .debug()
       .filter { $0 == .updateRequest }
       .map { _ in Reactor.Action.moveUpdate }
       .bind(to: reactor.action)

--- a/WalWal/Utility/Sources/AppUpdataManager.swift
+++ b/WalWal/Utility/Sources/AppUpdataManager.swift
@@ -17,52 +17,30 @@ public final class AppUpdateManager {
   private init() {}
   
   public func checkForUpdate() {
-    guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
-      print("Failed to get the current version.")
-      return
-    }
-    guard let bundleId = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String else {
-      print("Failed to get the current version.")
-      return
-    }
-    fetchAppStoreVersion(bundleID: bundleId) { [weak self] appStoreVersion in
-      guard let self = self, let appStoreVersion = appStoreVersion else {
-        print("Failed to fetch the App Store version.")
+    Task {
+      guard
+        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+        let bundleId = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String,
+        let appStoreVersion = await fetchAppStoreVersion(bundleID: bundleId)
+      else {
+        print("최신 앱 버전 / 현재 앱 버전을 가져오는데 실패했습니다. 😵")
         return
       }
       
-      DispatchQueue.main.async {
-        let scenes = UIApplication.shared.connectedScenes
-        let windowScene = scenes.first as? UIWindowScene
-        guard let window = windowScene?.windows.first else { return }
-        
-        let isNewVersionAvailable = currentVersion.compare(appStoreVersion, options: .numeric) == .orderedAscending
-        self.updateRequest.onNext(isNewVersionAvailable)
-      }
+      let isNewVersionAvailable = appStoreVersion > currentVersion /// 앱 스토어 버전이 현재 보다 높을 때
+      self.updateRequest.onNext(())
     }
   }
   
-  private func fetchAppStoreVersion(bundleID: String, completion: @escaping (String?) -> Void) {
+  private func fetchAppStoreVersion(bundleID: String) async -> String? {
     let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleID)")!
-    let task = URLSession.shared.dataTask(with: url) { data, response, error in
-      guard let data = data, error == nil else {
-        completion(nil)
-        return
-      }
-      
-      do {
-        if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-           let results = json["results"] as? [[String: Any]],
-           let appStoreVersion = results.first?["version"] as? String {
-          completion(appStoreVersion)
-        } else {
-          completion(nil)
-        }
-      } catch {
-        completion(nil)
-      }
-    }
-    task.resume()
+    do {
+      let (data, urlResponse) = try await URLSession.shared.data(from: url)
+      if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+         let results = json["results"] as? [[String: Any]],
+         let appStoreVersion = results.first?["version"] as? String {
+        return appStoreVersion
+      } else { return nil }
+    } catch { return nil }
   }
-  
 }

--- a/WalWal/Utility/Sources/AppUpdataManager.swift
+++ b/WalWal/Utility/Sources/AppUpdataManager.swift
@@ -27,15 +27,14 @@ public final class AppUpdateManager {
         return
       }
       
-      let isNewVersionAvailable = appStoreVersion > currentVersion /// 앱 스토어 버전이 현재 보다 높을 때
-      self.updateRequest.onNext(())
+      if appStoreVersion > currentVersion { updateRequest.onNext(()) }
     }
   }
   
   private func fetchAppStoreVersion(bundleID: String) async -> String? {
     let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleID)")!
     do {
-      let (data, urlResponse) = try await URLSession.shared.data(from: url)
+      let (data, _) = try await URLSession.shared.data(from: url)
       if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
          let results = json["results"] as? [[String: Any]],
          let appStoreVersion = results.first?["version"] as? String {

--- a/WalWal/Utility/Sources/AppUpdataManager.swift
+++ b/WalWal/Utility/Sources/AppUpdataManager.swift
@@ -12,7 +12,7 @@ import RxSwift
 public final class AppUpdateManager {
   
   public static let shared = AppUpdateManager()
-  public private(set) var updateRequest = PublishSubject<Bool>()
+  public private(set) var updateRequest = PublishSubject<Void>()
   
   private init() {}
   


### PR DESCRIPTION
## 📌 개요
- issue: #337 
음,,, 핫픽스 정도로 수정 하려고 했는데, 작업 하다보니 꽤 큰 규모의 수정이 들어갔네요 ㅎㅎ,,,,
코드 확인 해보시고 이해 안되는 부분 있으면 질문 주십셔

## ✍️ 변경사항
- Alert 이벤트는 ShowAlert을 통해 임시 상태로 저장되고, 이후 Ok Action 트리거를 통해 실제 스트림에 연결됩니다.
- Alert의 EventType을 정의하여, 필요 한 케이스를 커스텀하게 추가하도록 개선했습니다
  - 기존의 ok / close 보다, 이벤트 중심의 alert액션 동작 처리가 가능해집니다
- 외부에선 최대한 Alert 자체 프로퍼티에 접근하지 않도록 개선하고, Manager를 통해 Observer / Observable을 명확하게 구분하여 
실제 사용시에 보다 편리함을 제공합니다

### 사용 예시
showAlert에 bind를 해주면, Alert이 등장하면서 AlertEventType에 맞는 세팅값이 자동으로 설정됩니다.
이 때, AlertManager에서 관리하는 event의 상태는 임시저장 된 상태로 이후 okButton의 액션을 통해 실제 스트림으로 연결됩니다.
```swift
    reactor.state
      .map { $0.showAlert }
      .distinctUntilChanged()
      .filter { $0 }
      .map { _ in AlertEventType.report }
      .bind(to: WalWalAlert.shared.rx.showAlert)
      .disposed(by: disposeBag)
```

이처럼 okEvent에 대한 filter를 통해, 원하는 액션에 대한 구독처리가 가능하도록 구현하였습니다.
ok버튼을 통해 이벤트 처리가 필요하지 않을 경우(그냥 닫기만 될 때)에는 따로 구현 할 필요가 없습니다.
```swift
    WalWalAlert.shared.rx.okEvent
      .filter { $0 == .report }
      .bind(with: self) { owner, _ in
        owner.dismissView.accept(())
      }
      .disposed(by: disposeBag)
```

## 📷 스크린샷
수정 이후, 모든 Alert등장 케이스에 대해 테스트 해본 결과 정상동작 확인했슴다!
(촬영 하기에는 너무 많아서 ㅎ,,,,,)

## 🛠️ **Technical Concerns(기술적 고민)**
궁금한 내용 있으면 질문 주세요
