### PR TITLE
미션 완료 뷰 에러 해결

### DIFF
--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
@@ -193,7 +193,7 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
           .position(.absolute)
           .alignSelf(.center)
           .top(89.adjusted)
-          .marginHorizontal(20.adjusted)
+          .width(100%)
       }
     
     swapButton.flex

--- a/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
+++ b/WalWal/Features/Mission/MissionPresenter/Implement/Views/Components/Cell/RecordCarouselCell.swift
@@ -112,7 +112,7 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
   
   override func prepareForReuse() {
     super.prepareForReuse()
-    isRecordContainerVisible = true
+    resetCell()
   }
   
   override func layoutSubviews() {
@@ -220,6 +220,11 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
   
   private func bind() {
     swapButton.rx.tap
+      .throttle(
+        .milliseconds(300),
+        latest: false,
+        scheduler: MainScheduler.instance
+      )
       .bind(with: self) { owner, _ in
         owner.toggleContainers()
       }
@@ -263,6 +268,16 @@ final class RecordCarouselCell: UICollectionViewCell, ReusableView {
         self.setNeedsLayout()
       }
     }
+  }
+  
+  private func resetCell() {
+    isRecordContainerVisible = true
+    recordContainer.isHidden = false
+    missionInfoContainer.isHidden = true
+    
+    rootContainer.layer.transform = CATransform3DIdentity
+    recordContainer.alpha = 1.0
+    missionInfoContainer.alpha = 0.0
   }
   
   func configureCell(record: RecordList) {


### PR DESCRIPTION
## 📌 개요
- issue: #348 

## ✍️ 변경사항
 미션 완료뷰에서 발생하는 오류들을 해결했습니다. 
- 미션 카드 두번 클릭해야 기록이 나오는 현상 : 미션 카드뷰 재사용 이슈
- 타이틀 짤림 이슈
- 애니메이션 진행하는 동안 throttle

## 📷 스크린샷
![ScreenRecording_10-26-2024 23-22-05_1](https://github.com/user-attachments/assets/823cc1cc-1daa-4b12-8e0a-9e2700f85af8)


## 🛠️ **Technical Concerns(기술적 고민)**
